### PR TITLE
Add loop mode support for player and UI

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -38,5 +38,11 @@
     "UNKNOWN_TITLE": "Unknown Title",
     "LEFT_EMPTY": "Leaving voice channel because it is empty.",
     "QUEUE_ENDED": "Leaving voice channel because the queue finished.",
-    "LISTENING_TO_MUSIC": "music 🎵"
+    "LISTENING_TO_MUSIC": "music 🎵",
+    "LOOP_TRACK_ENABLED": "🔂 Track loop enabled",
+    "LOOP_QUEUE_ENABLED": "🔁 Queue loop enabled",
+    "LOOP_DISABLED": "➡️ Loop disabled",
+    "LOOP_STATUS": "Loop Mode",
+    "LOOP_STATUS_TRACK": "Track",
+    "LOOP_STATUS_QUEUE": "Queue"
 } 

--- a/locales/es.json
+++ b/locales/es.json
@@ -38,5 +38,11 @@
     "UNKNOWN_TITLE": "Título Desconocido",
     "LEFT_EMPTY": "Abandonando el canal de voz porque está vacío.",
     "QUEUE_ENDED": "Saliendo del canal de voz porque la lista de reproducción terminó.",
-    "LISTENING_TO_MUSIC": "música 🎵"
+    "LISTENING_TO_MUSIC": "música 🎵",
+    "LOOP_TRACK_ENABLED": "🔂 Bucle de pista activado",
+    "LOOP_QUEUE_ENABLED": "🔁 Bucle de cola activado",
+    "LOOP_DISABLED": "➡️ Bucle desactivado",
+    "LOOP_STATUS": "Modo de bucle",
+    "LOOP_STATUS_TRACK": "Pista",
+    "LOOP_STATUS_QUEUE": "Cola"
 } 

--- a/src/commands/loop.js
+++ b/src/commands/loop.js
@@ -1,0 +1,46 @@
+const { SlashCommandBuilder } = require('discord.js');
+
+module.exports = {
+    data: new SlashCommandBuilder()
+        .setName('loop')
+        .setDescription('Toggle loop mode for the current track or queue.'),
+    async execute(interaction) {
+        const { client } = interaction;
+        const { requirePlayer } = require('../utils/interactionHelpers');
+
+        const player = await requirePlayer(interaction);
+        if (!player) return;
+
+        // Cycle through loop modes: off -> track -> queue -> off
+        let newMode;
+        let modeMessage;
+        
+        switch (player.repeatMode) {
+            case 'off':
+                newMode = 'track';
+                modeMessage = client.languageManager.get(client.defaultLanguage, 'LOOP_TRACK_ENABLED');
+                break;
+            case 'track':
+                newMode = 'queue';
+                modeMessage = client.languageManager.get(client.defaultLanguage, 'LOOP_QUEUE_ENABLED');
+                break;
+            case 'queue':
+                newMode = 'off';
+                modeMessage = client.languageManager.get(client.defaultLanguage, 'LOOP_DISABLED');
+                break;
+            default:
+                newMode = 'track';
+                modeMessage = client.languageManager.get(client.defaultLanguage, 'LOOP_TRACK_ENABLED');
+        }
+
+        // Set the new repeat mode
+        player.setRepeatMode(newMode);
+
+        // Update the player display
+        setTimeout(() => {
+            client.playerController.updatePlayer(interaction.guild.id);
+        }, 100);
+
+        return interaction.reply({ content: modeMessage, ephemeral: true });
+    },
+}; 

--- a/src/commands/nowplaying.js
+++ b/src/commands/nowplaying.js
@@ -22,6 +22,20 @@ module.exports = {
 
         const embed = client.playerController.createPlayerEmbed(player, track);
 
+        // Add loop status to nowplaying
+        if (player.repeatMode && player.repeatMode !== 'off') {
+            const loopIcon = player.repeatMode === 'track' ? '🔂' : '🔁';
+            const loopText = player.repeatMode === 'track' 
+                ? client.languageManager.get(client.defaultLanguage, 'LOOP_STATUS_TRACK')
+                : client.languageManager.get(client.defaultLanguage, 'LOOP_STATUS_QUEUE');
+            
+            embed.addFields({
+                name: client.languageManager.get(client.defaultLanguage, 'LOOP_STATUS'),
+                value: `${loopIcon} ${loopText}`,
+                inline: true
+            });
+        }
+
         return interaction.reply({ embeds: [embed], ephemeral: true });
     },
 }; 

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -162,6 +162,37 @@ module.exports = {
                         responded = true;
                         break;
 
+                    case 'player_loop':
+                        // Cycle through loop modes
+                        let newMode;
+                        let modeMessage;
+                        
+                        switch (player.repeatMode || 'off') {
+                            case 'off':
+                                newMode = 'track';
+                                modeMessage = client.languageManager.get(lang, 'LOOP_TRACK_ENABLED');
+                                break;
+                            case 'track':
+                                newMode = 'queue';
+                                modeMessage = client.languageManager.get(lang, 'LOOP_QUEUE_ENABLED');
+                                break;
+                            case 'queue':
+                                newMode = 'off';
+                                modeMessage = client.languageManager.get(lang, 'LOOP_DISABLED');
+                                break;
+                            default:
+                                newMode = 'track';
+                                modeMessage = client.languageManager.get(lang, 'LOOP_TRACK_ENABLED');
+                        }
+
+                        player.setRepeatMode(newMode);
+                        await interaction.reply({ 
+                            content: modeMessage, 
+                            ephemeral: true 
+                        });
+                        responded = true;
+                        break;
+
                 }
 
                 // Update the player message after any action

--- a/src/utils/PlayerController.js
+++ b/src/utils/PlayerController.js
@@ -21,11 +21,23 @@ class PlayerController {
             .setFooter({ text: this.client.languageManager.get(lang, 'PLAYER_VOLUME', player.volume) })
             .setTimestamp();
 
+        // Add loop status to the embed
+        if (player.repeatMode && player.repeatMode !== 'off') {
+            const loopIcon = player.repeatMode === 'track' ? '🔂' : '🔁';
+            const loopText = player.repeatMode === 'track' 
+                ? this.client.languageManager.get(lang, 'LOOP_STATUS_TRACK')
+                : this.client.languageManager.get(lang, 'LOOP_STATUS_QUEUE');
+            embed.setFooter({ 
+                text: `${this.client.languageManager.get(lang, 'PLAYER_VOLUME', player.volume)} | ${loopIcon} ${loopText}` 
+            });
+        }
+
         return embed;
     }
 
     createPlayerButtons(player) {
         const isPaused = player.paused;
+        const loopIcon = player.repeatMode === 'track' ? '🔂' : player.repeatMode === 'queue' ? '🔁' : '➡️';
         
         const row1 = new ActionRowBuilder()
             .addComponents(
@@ -53,6 +65,10 @@ class PlayerController {
                     .setCustomId('player_shuffle')
                     .setEmoji('🔀')
                     .setStyle(ButtonStyle.Secondary),
+                new ButtonBuilder()
+                    .setCustomId('player_loop')
+                    .setEmoji(loopIcon)
+                    .setStyle(player.repeatMode !== 'off' ? ButtonStyle.Success : ButtonStyle.Secondary),
                 new ButtonBuilder()
                     .setCustomId('player_queue')
                     .setEmoji('📜')


### PR DESCRIPTION
Introduces a /loop command and player button to toggle loop modes (off, track, queue). Updates nowplaying and player embed to display loop status, and adds localized strings for loop messages in English and Spanish.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add loop mode functionality to the player, including UI updates and interaction handling.

### Why are these changes being made?

To enhance user experience by allowing cycling through loop modes (track, queue, off) via new commands and interface elements. This feature enables users to control and visualize the looping status of their music, addressing a common user request for advanced playback options.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->