### PR TITLE
Add /loop command to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ To restrict bot usage to specific roles:
 | `/skip` | Skip the current song |
 | `/stop` | Stop playback and clear the queue |
 | `/pause` | Toggle pause/resume |
+| `/loop` | Toggle loop mode (off/track/queue) |
 | `/queue` | Show the current queue |
 | `/nowplaying` | Show info about the current song |
 | `/shuffle` | Shuffle the queue |

--- a/docs/index.html
+++ b/docs/index.html
@@ -231,6 +231,14 @@
                         
                         <div class="command-item">
                             <div class="command-header">
+                                <code>/loop</code>
+                                <span class="badge bg-info">Playback</span>
+                            </div>
+                            <p>Toggle loop mode for current track or queue</p>
+                        </div>
+                        
+                        <div class="command-item">
+                            <div class="command-header">
                                 <code>/queue</code>
                                 <span class="badge bg-secondary">Info</span>
                             </div>


### PR DESCRIPTION
Documented the new /loop command in both README.md and docs/index.html, describing its function to toggle loop mode for the current track or queue.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add documentation for the `/loop` command to both the README and the online documentation.

### Why are these changes being made?

The addition of the `/loop` command documentation ensures users are informed about the new functionality, allowing them to toggle loop modes for playback, which enhances the user experience by providing more control over music playback options. This change fills in missing documentation for a feature already implemented in the system, closing the gap between available features and documented commands.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->