### PR TITLE
Refactor queue handling to support pagination

### DIFF
--- a/src/commands/queue.js
+++ b/src/commands/queue.js
@@ -1,4 +1,4 @@
-const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -7,18 +7,12 @@ module.exports = {
     async execute(interaction) {
         const { client } = interaction;
         const { requirePlayer } = require('../utils/interactionHelpers');
-        const { formattedQueue } = require('../utils/PlayerActions');
+        const { createPaginatedQueueResponse } = require('../utils/PlayerActions');
 
         const player = await requirePlayer(interaction, { requireQueue: true });
         if (!player) return;
 
-        const queueString = formattedQueue(player, 10);
-
-        const embed = new EmbedBuilder()
-            .setColor(0x0099FF)
-            .setTitle(client.languageManager.get(client.defaultLanguage, 'QUEUE_TITLE'))
-            .setDescription(queueString || client.languageManager.get(client.defaultLanguage, 'QUEUE_NO_TRACKS'));
-
-        return interaction.reply({ embeds: [embed], ephemeral: true });
+        const queueResponse = createPaginatedQueueResponse(client, player, 1);
+        return interaction.reply(queueResponse);
     },
 }; 

--- a/src/utils/PlayerActions.js
+++ b/src/utils/PlayerActions.js
@@ -2,7 +2,7 @@
 // slash-commands and component interactions to share the same core logic.
 
 /**
- * Plays the previous track in the queue if available.
+ * Plays the previous track from the queue history.
  * Returns the track that started playing, or null if none.
  */
 async function playPrevious(player) {
@@ -43,6 +43,89 @@ function clearQueue(player) {
     player.queue.tracks.splice(0, len);
 }
 
+function paginatedQueue(player, page = 1, itemsPerPage = 10) {
+    if (!player.queue.tracks.length) {
+        return {
+            content: '',
+            currentPage: 1,
+            totalPages: 1,
+            totalTracks: 0,
+            hasNext: false,
+            hasPrevious: false
+        };
+    }
+
+    const totalTracks = player.queue.tracks.length;
+    const totalPages = Math.ceil(totalTracks / itemsPerPage);
+    const currentPage = Math.max(1, Math.min(page, totalPages));
+    
+    const startIndex = (currentPage - 1) * itemsPerPage;
+    const endIndex = Math.min(startIndex + itemsPerPage, totalTracks);
+    
+    const tracks = player.queue.tracks.slice(startIndex, endIndex);
+    const list = tracks
+        .map((track, i) => `${startIndex + i + 1}. ${track.info?.title || 'Unknown'}`)
+        .join('\n');
+    
+    return {
+        content: list,
+        currentPage,
+        totalPages,
+        totalTracks,
+        hasNext: currentPage < totalPages,
+        hasPrevious: currentPage > 1,
+        startIndex: startIndex + 1,
+        endIndex
+    };
+}
+
+function createPaginatedQueueResponse(client, player, page = 1) {
+    const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+    const lang = client.defaultLanguage;
+    
+    const queueData = paginatedQueue(player, page);
+    
+    if (!queueData.content) {
+        return {
+            content: client.languageManager.get(lang, 'QUEUE_EMPTY'),
+            ephemeral: true
+        };
+    }
+    
+    const embed = new EmbedBuilder()
+        .setColor(0x0099FF)
+        .setTitle(client.languageManager.get(lang, 'QUEUE_TITLE'))
+        .setDescription(queueData.content)
+        .setFooter({ 
+            text: `Page ${queueData.currentPage}/${queueData.totalPages} • ${queueData.totalTracks} tracks • Showing ${queueData.startIndex}-${queueData.endIndex}`
+        });
+    
+    const components = [];
+    
+    if (queueData.totalPages > 1) {
+        const row = new ActionRowBuilder()
+            .addComponents(
+                new ButtonBuilder()
+                    .setCustomId(`queue_prev_${page - 1}`)
+                    .setEmoji('⬅️')
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(!queueData.hasPrevious),
+                new ButtonBuilder()
+                    .setCustomId(`queue_next_${page + 1}`)
+                    .setEmoji('➡️')
+                    .setStyle(ButtonStyle.Secondary)
+                    .setDisabled(!queueData.hasNext)
+            );
+        components.push(row);
+    }
+    
+    return {
+        embeds: [embed],
+        components,
+        ephemeral: true
+    };
+}
+
 function formattedQueue(player, limit = 10) {
     if (!player.queue.tracks.length) return '';
     const list = player.queue.tracks
@@ -58,4 +141,6 @@ module.exports = {
     shuffleQueue,
     clearQueue,
     formattedQueue,
+    paginatedQueue,
+    createPaginatedQueueResponse,
 }; 


### PR DESCRIPTION
- Removed the old queue display logic and replaced it with a new paginated response system in `queue.js` and `interactionCreate.js`.
- Introduced `createPaginatedQueueResponse` and `paginatedQueue` functions in `PlayerActions.js` to manage queue pagination.
- Updated button interaction handling to include pagination controls for navigating through the queue.

This improves user experience by allowing users to view large queues in a more manageable way.

resolves #22 

![Discord_B0lJvRrCwY](https://github.com/user-attachments/assets/9586d335-591d-4c11-b568-a590bacb1553)

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Refactor the queue handling in the discord bot to support pagination, allowing users to navigate through tracks in the queue using buttons.

### Why are these changes being made?

The refactoring introduces a new paginated queue handling system, providing a better user experience by allowing interaction with buttons to navigate through long queues. This change addresses the limitation of displaying only a fixed number of tracks and enhances the user interface by providing more dynamic interaction.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->