### PR TITLE
Users can now customize the default volume by adding or modifying the…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,4 +22,5 @@ EMPTY_CHANNEL_DESTROY_MS=60000
 ALLOWED_ROLES=
 
 # Optional: Audio Settings
+# Default volume for music playback (0-100, defaults to 80 if not set or invalid)
 DEFAULT_VOLUME=80

--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ EMPTY_CHANNEL_DESTROY_MS=60000
 # Leave empty to allow everyone to use the bot
 # Example: ALLOWED_ROLES=123456789012345678,234567890123456789
 ALLOWED_ROLES=
+
+# Optional: Audio Settings
+DEFAULT_VOLUME=80

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ EMPTY_CHANNEL_DESTROY_MS=60000
 # Leave empty to allow everyone to use the bot
 # Example: ALLOWED_ROLES=123456789012345678,234567890123456789
 ALLOWED_ROLES=
+
+# Optional: Audio Settings
+DEFAULT_VOLUME=80
 ```
 
 ### 3. Deploy commands & start the bot

--- a/docs/index.html
+++ b/docs/index.html
@@ -329,7 +329,10 @@ LAVALINK_PASSWORD=youshallnotpass
 
 # Optional Settings
 DEFAULT_LANGUAGE=en
-ALLOWED_ROLES=</code></pre>
+ALLOWED_ROLES=
+
+# Optional: Audio Settings
+DEFAULT_VOLUME=80</code></pre>
                                     <button class="copy-btn" data-clipboard-target="#code2">
                                         <i class="fas fa-copy"></i>
                                     </button>
@@ -452,4 +455,4 @@ ALLOWED_ROLES=</code></pre>
     <!-- Custom JS -->
     <script src="script.js"></script>
 </body>
-</html> 
+</html>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "beatdock",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A modern and efficient Discord music bot with slash commands, multi-language support, and Docker deployment.",
   "main": "src/index.js",
   "scripts": {
@@ -41,4 +41,4 @@
     "dotenv": "^16.5.0",
     "lavalink-client": "^2.5.6"
   }
-} 
+}

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -1,5 +1,12 @@
 const { SlashCommandBuilder } = require('discord.js');
 
+// Validate and clamp volume to valid range (0-100)
+function getValidVolume(envValue, defaultValue = 80) {
+    const parsed = parseInt(envValue, 10);
+    if (isNaN(parsed)) return defaultValue;
+    return Math.max(0, Math.min(100, parsed)); // Clamp between 0-100
+}
+
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('play')
@@ -26,7 +33,7 @@ module.exports = {
             textChannelId: interaction.channel.id,
             selfDeaf: true,
             selfMute: false,
-            volume: parseInt(process.env.DEFAULT_VOLUME || '80', 10),
+            volume: getValidVolume(process.env.DEFAULT_VOLUME, 80),
         });
 
         if(player.voiceChannelId !== voiceChannel.id) {

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -26,7 +26,7 @@ module.exports = {
             textChannelId: interaction.channel.id,
             selfDeaf: true,
             selfMute: false,
-            volume: 80,
+            volume: parseInt(process.env.DEFAULT_VOLUME || '80', 10),
         });
 
         if(player.voiceChannelId !== voiceChannel.id) {
@@ -70,4 +70,4 @@ module.exports = {
             await client.playerController.sendPlayer(interaction.channel, player);
         }
     },
-}; 
+};


### PR DESCRIPTION
… DEFAULT_VOLUME value in their .env file:

```env
# Set default volume to 50% instead of 80%
DEFAULT_VOLUME=50
```

The bot will automatically use this value when creating new music players. If no value is specified, it defaults to 80 (the original hardcoded value), ensuring no breaking changes.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Allow users to customize the default audio volume by adding or modifying the `DEFAULT_VOLUME` environment variable in the configuration files.

### Why are these changes being made?

This change introduces flexibility for user preferences by enabling custom default volume settings, which is particularly useful for users who prefer a different starting volume than the hardcoded default. The approach ensures the volume is clamped within a valid range (0-100) to prevent errors, and it aligns with the default value of 80 if the environment variable is not set or is invalid. This enhances user experience by offering configurability and maintaining system integrity with input validation.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->