### PR TITLE
Add support for configurable Lavalink password

### DIFF
--- a/application.yml
+++ b/application.yml
@@ -19,7 +19,7 @@ lavalink:
     - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.3"
       snapshot: false
   server:
-    password: "youshallnotpass"
+    password: "${LAVALINK_PASSWORD:youshallnotpass}"
     sources:
       youtube: false
       soundcloud: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - beatdock-network
     volumes:
       - ./application.yml:/opt/Lavalink/application.yml
+    environment:
+      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
 
 networks:
   beatdock-network:


### PR DESCRIPTION
Updated application.yml and docker-compose.yml to allow the Lavalink server password to be set via the LAVALINK_PASSWORD environment variable, improving configuration flexibility.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add support for a configurable Lavalink password by introducing an environment variable `LAVALINK_PASSWORD` in the configuration files.

### Why are these changes being made?

These changes allow users to configure the Lavalink server password through environment variables, enhancing the application's security and flexibility by enabling dynamic password management without altering the code directly. This approach uses a default password if the environment variable is not provided, maintaining backward compatibility.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->