### PR TITLE
docs: add community-contributed ARM64 Docker image documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,26 @@ docker compose logs -f  # CTRL+C to stop viewing
 
 Docker Desktop will automatically start the containers whenever you reboot (unless disabled in settings).
 
+## Community-Contributed Prebuilt Docker Image (ARM64)
+
+A prebuilt Docker image for ARM64 platforms (e.g., Raspberry Pi 5) has been made available by community contributor **@driftywinds**. This is intended for users who don't want to rebuild the image on every update.
+
+> **Important Note**: This is a community-based contribution and not officially maintained by the BeatDock core team. We greatly appreciate @driftywinds for providing this resource to the community.
+
+### Available Images
+
+The following container registries host the ARM64 image (in order of recommendation):
+
+1. **GitHub Container Registry (recommended)**: `ghcr.io/driftywinds/beatdock-bot:latest`
+2. **Quay.io**: `quay.io/driftywinds/beatdock-bot:latest`
+3. **Docker Hub**: `docker.io/driftywinds/beatdock-bot:latest`
+
+### Usage Instructions
+
+Simply copy and paste the desired image tag into your `docker-compose.yml` file, and it should work out of the box on compatible ARM64 devices.
+
+For more details, see the original discussion in [Issue #32](https://github.com/lazaroagomez/BeatDock/issues/32).
+
 ## Support
 
 - **Issues**: [GitHub Issues](https://github.com/lazaroagomez/BeatDock/issues)

--- a/docs/index.html
+++ b/docs/index.html
@@ -429,6 +429,71 @@ DEFAULT_VOLUME=80</code></pre>
                     </div>
                 </div>
             </div>
+            
+            <!-- Community ARM64 Docker Image Section -->
+            <div class="row mt-5">
+                <div class="col-lg-10 mx-auto">
+                    <div class="section-header text-center mb-4">
+                        <h3 class="gaming-font">
+                            <span class="text-gradient">Community-Contributed Prebuilt Docker Image (ARM64)</span>
+                        </h3>
+                    </div>
+                    
+                    <div class="alert alert-info mb-4">
+                        <div class="d-flex align-items-start">
+                            <i class="fas fa-users text-info me-3 mt-1"></i>
+                            <div>
+                                <h5 class="alert-heading mb-2">Community Contribution</h5>
+                                <p class="mb-2">A prebuilt Docker image for ARM64 platforms (e.g., Raspberry Pi 5) has been made available by community contributor <strong>@driftywinds</strong>. This is intended for users who don't want to rebuild the image on every update.</p>
+                                <p class="mb-0"><strong>Important:</strong> This is a community-based contribution and not officially maintained by the BeatDock core team. We greatly appreciate @driftywinds for providing this resource to the community.</p>
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div class="row">
+                        <div class="col-md-8 mx-auto">
+                            <h5 class="mb-3"><i class="fas fa-microchip text-primary me-2"></i>Available Images</h5>
+                            <p class="mb-3">The following container registries host the ARM64 image (in order of recommendation):</p>
+                            
+                            <div class="list-group mb-4">
+                                <div class="list-group-item bg-dark border-secondary">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <h6 class="mb-1 text-success">GitHub Container Registry <span class="badge bg-success ms-2">Recommended</span></h6>
+                                            <code class="text-light">ghcr.io/driftywinds/beatdock-bot:latest</code>
+                                        </div>
+                                        <i class="fab fa-github text-success"></i>
+                                    </div>
+                                </div>
+                                <div class="list-group-item bg-dark border-secondary">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <h6 class="mb-1">Quay.io</h6>
+                                            <code class="text-light">quay.io/driftywinds/beatdock-bot:latest</code>
+                                        </div>
+                                        <i class="fas fa-cloud text-info"></i>
+                                    </div>
+                                </div>
+                                <div class="list-group-item bg-dark border-secondary">
+                                    <div class="d-flex justify-content-between align-items-center">
+                                        <div>
+                                            <h6 class="mb-1">Docker Hub</h6>
+                                            <code class="text-light">docker.io/driftywinds/beatdock-bot:latest</code>
+                                        </div>
+                                        <i class="fab fa-docker text-primary"></i>
+                                    </div>
+                                </div>
+                            </div>
+                            
+                            <div class="alert alert-light text-dark">
+                                <h6 class="alert-heading mb-2"><i class="fas fa-info-circle text-primary me-2"></i>Usage Instructions</h6>
+                                <p class="mb-2">Simply copy and paste the desired image tag into your <code>docker-compose.yml</code> file, and it should work out of the box on compatible ARM64 devices.</p>
+                                <p class="mb-0">For more details, see the original discussion in <a href="https://github.com/lazaroagomez/BeatDock/issues/32" target="_blank" class="text-primary"><i class="fas fa-external-link-alt me-1"></i>Issue #32</a>.</p>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </section>
 


### PR DESCRIPTION
- Add new section in README.md documenting prebuilt ARM64 Docker images

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Add documentation for the community-contributed prebuilt ARM64 Docker image to both the README.md and the website's documentation.

### Why are these changes being made?

These changes are introduced to provide users, particularly those running on ARM64 platforms like Raspberry Pi, with an easy way to use a community-contributed Docker image without having to rebuild it themselves. The documentation clarifies the availability of this resource and includes instructions for seamless integration.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->