### PR TITLE
feat: add GitHub Actions Docker publishing workflow and update docs

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,51 @@
+name: Build and Publish Docker Image
+
+on:
+  push:
+    branches: [ main ]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=sha,prefix={{branch}}-
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -89,7 +89,50 @@ ALLOWED_ROLES=
 DEFAULT_VOLUME=80
 ```
 
-### 3. Deploy commands & start the bot
+### 3. Update docker-compose.yml to use the official image
+
+Replace the `build` section in your `docker-compose.yml` with:
+
+```yaml
+services:
+  bot:
+    container_name: beatdock
+    image: ghcr.io/lazaroagomez/beatdock:latest
+    depends_on:
+      - lavalink
+    networks:
+      - beatdock-network
+    env_file: .env
+```
+
+### 4. Deploy commands & start the bot
+
+```bash
+# Deploy slash commands
+docker compose run --rm bot npm run deploy
+
+# Start the bot
+docker compose up -d
+```
+
+## Build from Source
+
+If you prefer to build the Docker image yourself instead of using the pre-built image:
+
+### 1. Use the original docker-compose.yml
+
+Keep the original `build` configuration:
+
+```yaml
+services:
+  bot:
+    container_name: beatdock
+    build:
+      context: .
+      dockerfile: Dockerfile
+```
+
+### 2. Build and start
 
 ```bash
 # Deploy slash commands
@@ -186,25 +229,9 @@ docker compose logs -f  # CTRL+C to stop viewing
 
 Docker Desktop will automatically start the containers whenever you reboot (unless disabled in settings).
 
-## Community-Contributed Prebuilt Docker Image (ARM64)
+## Community ARM64 Image
 
-A prebuilt Docker image for ARM64 platforms (e.g., Raspberry Pi 5) has been made available by community contributor **@driftywinds**. This is intended for users who don't want to rebuild the image on every update.
-
-> **Important Note**: This is a community-based contribution and not officially maintained by the BeatDock core team. We greatly appreciate @driftywinds for providing this resource to the community.
-
-### Available Images
-
-The following container registries host the ARM64 image (in order of recommendation):
-
-1. **GitHub Container Registry (recommended)**: `ghcr.io/driftywinds/beatdock-bot:latest`
-2. **Quay.io**: `quay.io/driftywinds/beatdock-bot:latest`
-3. **Docker Hub**: `docker.io/driftywinds/beatdock-bot:latest`
-
-### Usage Instructions
-
-Simply copy and paste the desired image tag into your `docker-compose.yml` file, and it should work out of the box on compatible ARM64 devices.
-
-For more details, see the original discussion in [Issue #32](https://github.com/lazaroagomez/BeatDock/issues/32).
+Thanks to **@driftywinds** for providing an ARM64 community image at `ghcr.io/driftywinds/beatdock-bot:latest`. See [Issue #32](https://github.com/lazaroagomez/BeatDock/issues/32) for details.
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -91,18 +91,38 @@ DEFAULT_VOLUME=80
 
 ### 3. Update docker-compose.yml to use the official image
 
-Replace the `build` section in your `docker-compose.yml` with:
+Replace the bot service's `build` section with the pre-built image:
 
 ```yaml
+# Complete docker-compose.yml configuration
 services:
   bot:
     container_name: beatdock
-    image: ghcr.io/lazaroagomez/beatdock:latest
+    image: ghcr.io/lazaroagomez/beatdock:latest  # Use official image instead of build
     depends_on:
       - lavalink
     networks:
       - beatdock-network
     env_file: .env
+
+  lavalink:
+    container_name: beatdock-lavalink
+    image: ghcr.io/lavalink-devs/lavalink:4-alpine
+    ports:
+      - "2333:2333"
+    networks:
+      - beatdock-network
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+    environment:
+      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
+      - SPOTIFY_ENABLED=${SPOTIFY_ENABLED:-false}
+      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
+      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
+
+networks:
+  beatdock-network:
+    name: beatdock_network
 ```
 
 ### 4. Deploy commands & start the bot

--- a/docs/index.html
+++ b/docs/index.html
@@ -402,17 +402,37 @@ DEFAULT_VOLUME=80</code></pre>
                             <div class="step-number">4</div>
                             <div class="step-content">
                                 <h4>Use Official Docker Image</h4>
-                                <p>Update your <code>docker-compose.yml</code> to use the pre-built image</p>
+                                <p>Replace the bot service's <code>build</code> section with the pre-built image:</p>
                                 <div class="code-block">
-                                    <pre><code>services:
+                                    <pre><code># Complete docker-compose.yml configuration
+services:
   bot:
     container_name: beatdock
-    image: ghcr.io/lazaroagomez/beatdock:latest
+    image: ghcr.io/lazaroagomez/beatdock:latest  # Use official image instead of build
     depends_on:
       - lavalink
     networks:
       - beatdock-network
-    env_file: .env</code></pre>
+    env_file: .env
+
+  lavalink:
+    container_name: beatdock-lavalink
+    image: ghcr.io/lavalink-devs/lavalink:4-alpine
+    ports:
+      - "2333:2333"
+    networks:
+      - beatdock-network
+    volumes:
+      - ./application.yml:/opt/Lavalink/application.yml
+    environment:
+      - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
+      - SPOTIFY_ENABLED=${SPOTIFY_ENABLED:-false}
+      - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
+      - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
+
+networks:
+  beatdock-network:
+    name: beatdock_network</code></pre>
                                     <button class="copy-btn" data-clipboard-target="#code3">
                                         <i class="fas fa-copy"></i>
                                     </button>

--- a/docs/index.html
+++ b/docs/index.html
@@ -401,10 +401,18 @@ DEFAULT_VOLUME=80</code></pre>
                         <div class="setup-step">
                             <div class="step-number">4</div>
                             <div class="step-content">
-                                <h4>Deploy Commands</h4>
-                                <p>Register slash commands with Discord</p>
+                                <h4>Use Official Docker Image</h4>
+                                <p>Update your <code>docker-compose.yml</code> to use the pre-built image</p>
                                 <div class="code-block">
-                                    <pre><code>docker compose run --rm bot npm run deploy</code></pre>
+                                    <pre><code>services:
+  bot:
+    container_name: beatdock
+    image: ghcr.io/lazaroagomez/beatdock:latest
+    depends_on:
+      - lavalink
+    networks:
+      - beatdock-network
+    env_file: .env</code></pre>
                                     <button class="copy-btn" data-clipboard-target="#code3">
                                         <i class="fas fa-copy"></i>
                                     </button>
@@ -416,10 +424,11 @@ DEFAULT_VOLUME=80</code></pre>
                         <div class="setup-step">
                             <div class="step-number">5</div>
                             <div class="step-content">
-                                <h4>Start the Bot</h4>
-                                <p>Launch BeatDock with Docker Compose</p>
+                                <h4>Deploy Commands & Start</h4>
+                                <p>Register slash commands and launch BeatDock</p>
                                 <div class="code-block">
-                                    <pre><code>docker compose up -d</code></pre>
+                                    <pre><code>docker compose run --rm bot npm run deploy
+docker compose up -d</code></pre>
                                     <button class="copy-btn" data-clipboard-target="#code4">
                                         <i class="fas fa-copy"></i>
                                     </button>
@@ -430,67 +439,37 @@ DEFAULT_VOLUME=80</code></pre>
                 </div>
             </div>
             
-            <!-- Community ARM64 Docker Image Section -->
+            <!-- Build from Source Section -->
             <div class="row mt-5">
                 <div class="col-lg-10 mx-auto">
                     <div class="section-header text-center mb-4">
                         <h3 class="gaming-font">
-                            <span class="text-gradient">Community-Contributed Prebuilt Docker Image (ARM64)</span>
+                            <span class="text-gradient">Build from Source</span>
                         </h3>
+                        <p class="text-muted">If you prefer to build the Docker image yourself</p>
                     </div>
                     
-                    <div class="alert alert-info mb-4">
+                    <div class="alert alert-secondary mb-4">
                         <div class="d-flex align-items-start">
-                            <i class="fas fa-users text-info me-3 mt-1"></i>
+                            <i class="fas fa-tools text-secondary me-3 mt-1"></i>
                             <div>
-                                <h5 class="alert-heading mb-2">Community Contribution</h5>
-                                <p class="mb-2">A prebuilt Docker image for ARM64 platforms (e.g., Raspberry Pi 5) has been made available by community contributor <strong>@driftywinds</strong>. This is intended for users who don't want to rebuild the image on every update.</p>
-                                <p class="mb-0"><strong>Important:</strong> This is a community-based contribution and not officially maintained by the BeatDock core team. We greatly appreciate @driftywinds for providing this resource to the community.</p>
+                                <h5 class="alert-heading mb-2">Alternative Setup</h5>
+                                <p class="mb-2">Keep the original <code>build</code> configuration in your docker-compose.yml instead of using the pre-built image.</p>
+                                <div class="code-block mt-3">
+                                    <pre><code>services:
+  bot:
+    container_name: beatdock
+    build:
+      context: .
+      dockerfile: Dockerfile</code></pre>
+                                </div>
+                                <p class="mb-0 mt-2">Then follow the same steps to deploy commands and start the bot.</p>
                             </div>
                         </div>
                     </div>
                     
-                    <div class="row">
-                        <div class="col-md-8 mx-auto">
-                            <h5 class="mb-3"><i class="fas fa-microchip text-primary me-2"></i>Available Images</h5>
-                            <p class="mb-3">The following container registries host the ARM64 image (in order of recommendation):</p>
-                            
-                            <div class="list-group mb-4">
-                                <div class="list-group-item bg-dark border-secondary">
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <h6 class="mb-1 text-success">GitHub Container Registry <span class="badge bg-success ms-2">Recommended</span></h6>
-                                            <code class="text-light">ghcr.io/driftywinds/beatdock-bot:latest</code>
-                                        </div>
-                                        <i class="fab fa-github text-success"></i>
-                                    </div>
-                                </div>
-                                <div class="list-group-item bg-dark border-secondary">
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <h6 class="mb-1">Quay.io</h6>
-                                            <code class="text-light">quay.io/driftywinds/beatdock-bot:latest</code>
-                                        </div>
-                                        <i class="fas fa-cloud text-info"></i>
-                                    </div>
-                                </div>
-                                <div class="list-group-item bg-dark border-secondary">
-                                    <div class="d-flex justify-content-between align-items-center">
-                                        <div>
-                                            <h6 class="mb-1">Docker Hub</h6>
-                                            <code class="text-light">docker.io/driftywinds/beatdock-bot:latest</code>
-                                        </div>
-                                        <i class="fab fa-docker text-primary"></i>
-                                    </div>
-                                </div>
-                            </div>
-                            
-                            <div class="alert alert-light text-dark">
-                                <h6 class="alert-heading mb-2"><i class="fas fa-info-circle text-primary me-2"></i>Usage Instructions</h6>
-                                <p class="mb-2">Simply copy and paste the desired image tag into your <code>docker-compose.yml</code> file, and it should work out of the box on compatible ARM64 devices.</p>
-                                <p class="mb-0">For more details, see the original discussion in <a href="https://github.com/lazaroagomez/BeatDock/issues/32" target="_blank" class="text-primary"><i class="fas fa-external-link-alt me-1"></i>Issue #32</a>.</p>
-                            </div>
-                        </div>
+                    <div class="alert alert-info">
+                        <p class="mb-0"><strong>Community ARM64 Image:</strong> Thanks to <strong>@driftywinds</strong> for providing an ARM64 community image at <code>ghcr.io/driftywinds/beatdock-bot:latest</code>. See <a href="https://github.com/lazaroagomez/BeatDock/issues/32" target="_blank" class="text-light"><i class="fas fa-external-link-alt me-1"></i>Issue #32</a> for details.</p>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
- Add docker-publish.yml workflow for automatic GHCR publishing on main branch pushes
- Update README and docs to prioritize official Docker image over building from source
- Simplify community ARM64 contribution section to 1-2 lines
- Add Build from Source section as alternative option

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?
Add a GitHub Actions workflow for automatic Docker image publishing and update related documentation to utilize the pre-built Docker images.

### Why are these changes being made?
The changes automate the Docker image build and publish process using GitHub Actions, allowing users to deploy the latest pre-built Docker images easily, enhancing deployment efficiency and reducing the need for manual image builds. The updates also streamline documentation, guiding users towards using these official images for smoother setup and deployment.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->