### PR TITLE
feat (player): add default search platform configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ DEFAULT_VOLUME=80
 # Set to true to enable autoplay by default when music starts playing (default: false)
 #AUTOPLAY_DEFAULT=false
 
+# Optional: Default Search Platform Settings
+# Default search platform for user queries (default: ytsearch)
+# Supported platforms include: ytsearch (YouTube), ytmsearch (YouTube Music), and more depending on your Lavalink setup.
+# Platform Options: https://lc4.gitbook.io/lavalink-client/docs/other-types/searchplatform/lavalinksearchplatform
+DEFAULT_SEARCH_PLATFORM=ytsearch
+
 # Optional: Logging Settings
 # Log level: debug, info, warn, error (default: info)
 #LOG_LEVEL=info

--- a/README.md
+++ b/README.md
@@ -221,6 +221,7 @@ All configuration is done through the `.env` file. Only `TOKEN` is required.
 | `DEFAULT_VOLUME` | `80` | Default playback volume (0-100) |
 | `AUTOPLAY_DEFAULT` | `false` | Enable autoplay by default when music starts |
 | `ALLOWED_ROLES` | - | Comma-separated role IDs to restrict access |
+| `DEFAULT_SEARCH_PLATFORM` | `ytsearch` | Default search platform for user queries | 
 | `LAVALINK_PASSWORD` | `youshallnotpass` | Lavalink server password |
 | `QUEUE_EMPTY_DESTROY_MS` | `30000` | Disconnect after queue empties (ms) |
 | `EMPTY_CHANNEL_DESTROY_MS` | `60000` | Disconnect from empty channel (ms) |

--- a/src/index.js
+++ b/src/index.js
@@ -113,7 +113,7 @@ async function setupLavalink(client) {
         autoSkip: true,
         playerOptions: {
             clientBasedPositionUpdateInterval: 1000,
-            defaultSearchPlatform: "ytsearch",
+            defaultSearchPlatform: process.env.DEFAULT_SEARCH_PLATFORM || "ytsearch",
             onEmptyQueue: {
                 destroyAfterMs: parseInt(process.env.QUEUE_EMPTY_DESTROY_MS || "30000", 10),
                 autoPlayFunction: async (player, lastPlayedTrack) => {


### PR DESCRIPTION
## What does this PR do?

Provides a configuration override for the `defaultSearchPlatform` via environment variables.

**Problem:** The search platform is currently hardcoded to `ytsearch`, which often prioritizes high-view count or popular content over music content.

**Solution:** Added `DEFAULT_SEARCH_PLATFORM` to the configuration. It still defaults to `ytsearch` to maintain backward compatibility but allows hosts to switch to a preferred platform for their users, such as `ytmsearch` (YouTube Music) for better song matching.

## How to test

1. Start the bot without the new env variable and run `/play lockjaw`. Verify it returns a non-music video.
2. Add `DEFAULT_SEARCH_PLATFORM=ytmsearch` to the `.env`.
3. Restart the bot and run `/play lockjaw`. Verify it returns the track [Lockjaw (feat. Kodak Black)](https://www.youtube.com/watch?v=b7dJn2X_TyI).

## Changelog

### Added
- `DEFAULT_SEARCH_PLATFORM` environment variable to enable host to override the default search platform.

## Checklist

- [X] Tested manually with a running bot instance
- [X] Follows existing code patterns and conventions
- [X] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org)
- [X] Updated relevant documentation (README, CHANGELOG, etc.) if applicable
