### PR TITLE
2.8.1: lifecycle, SSRF, public-node, and ops hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,7 +16,9 @@ pnpm-debug.log*
 .gitattributes
 
 # Documentation
-README.md
+*.md
+*.MD
+!README.md
 LICENSE
 CHANGELOG.md
 docs/
@@ -39,6 +41,7 @@ compose*.yml
 Thumbs.db
 *.swp
 *.swo
+*.local
 
 # Test files
 test/
@@ -49,4 +52,4 @@ coverage/
 # Build files
 dist/
 build/
-*.log 
+*.log

--- a/.env.example
+++ b/.env.example
@@ -15,6 +15,9 @@ SPOTIFY_CLIENT_SECRET=your_spotify_client_secret_here
 LAVALINK_HOST=lavalink
 LAVALINK_PORT=2333
 LAVALINK_PASSWORD=youshallnotpass
+# Optional: restrict public Lavalink fallback to specific hosts or wildcard domains.
+# Example: PUBLIC_NODE_HOST_ALLOWLIST=node.example.com,*.trusted-lavalink.net
+#PUBLIC_NODE_HOST_ALLOWLIST=
 
 # Optional: Language Settings
 #DEFAULT_LANGUAGE=en

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,4 +27,7 @@ jobs:
         run: npm ci
 
       - name: Check syntax
-        run: node --check src/**/*.js
+        run: find src -name '*.js' -exec node --check {} +
+
+      - name: npm audit (production)
+        run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -61,6 +61,8 @@ jobs:
           context: .
           platforms: ${{ matrix.platform }}
           labels: ${{ steps.meta.outputs.labels }}
+          provenance: mode=max
+          sbom: true
           outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
           cache-from: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ matrix.platform }}
           cache-to: type=gha,scope=${{ github.repository }}-${{ github.ref_name }}-${{ matrix.platform }},mode=max

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -12,36 +12,36 @@ jobs:
   security:
     name: Security Analysis
     runs-on: ubuntu-latest
-    
+
     permissions:
       actions: read
       contents: read
       security-events: write
-      
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v6
-      
+
     - name: Run Trivy vulnerability scanner
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         scan-type: 'fs'
         scan-ref: '.'
         format: 'sarif'
         output: 'trivy-results.sarif'
-        
+
     - name: Upload Trivy scan results
       uses: github/codeql-action/upload-sarif@v4
       with:
         sarif_file: 'trivy-results.sarif'
-        
+
     # Build the Docker image locally so the subsequent image scan has an image to analyse
     - name: Build Docker image for scan
       run: docker build -t beatdock:latest .
-        
+
     - name: Docker security scan
-      uses: aquasecurity/trivy-action@master
+      uses: aquasecurity/trivy-action@v0.35.0
       with:
         scan-type: 'image'
         image-ref: 'beatdock:latest'
-        format: 'table' 
+        format: 'table'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:22.21-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -7,10 +7,10 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --omit=dev --ignore-engines
+RUN npm ci --omit=dev
 
 # Production stage
-FROM node:22.21-alpine
+FROM node:22-alpine
 
 # Add runtime dependencies
 RUN apk add --no-cache tini
@@ -32,6 +32,9 @@ USER nodejs
 
 # Use tini as entrypoint for proper signal handling
 ENTRYPOINT ["/sbin/tini", "--"]
+
+# Verify the bot is still writing its runtime heartbeat.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s --retries=3 CMD ["node", "-e", "const fs=require('fs');const p=process.env.HEALTHCHECK_HEARTBEAT_PATH||'/tmp/beatdock-alive';try{const s=fs.statSync(p);process.exit(Date.now()-s.mtimeMs<120000?0:1)}catch{process.exit(1)}"]
 
 # Start the application
 CMD ["node", "src/index.js"]

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A Discord music bot powered by Lavalink. Simple to deploy, easy to use.
 - Autoplay mode for continuous music playback
 - Queue management with shuffle, loop, and play-next
 - Interactive search with track selection
-- Multi-language support (English, Spanish, Turkish, Italian, Brazilian Portuguese)
+- Deploy-time language selection (English, Spanish, Turkish, Italian, Brazilian Portuguese)
 - Role-based access control
 - Runs entirely in Docker, no host dependencies
 - Works without a self-hosted Lavalink server (automatic public server fallback)
@@ -86,14 +86,14 @@ services:
     networks:
       - beatdock-network
     volumes:
-      - ./application.yml:/opt/Lavalink/application.yml
+      - ./application.yml:/opt/Lavalink/application.yml:ro
     environment:
       - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
       - SPOTIFY_ENABLED=${SPOTIFY_ENABLED:-false}
       - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/2333'"]
+      test: ["CMD", "/bin/bash", "-c", "echo > /dev/tcp/localhost/2333"]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -134,7 +134,7 @@ lavalink:
       bandcamp: true
       twitch: true
       vimeo: true
-      http: true
+      http: false
       local: false
     bufferDurationMs: 200
     frameBufferDurationMs: 1000
@@ -142,7 +142,8 @@ lavalink:
     playerUpdateInterval: 2
     trackStuckThresholdMs: 5000
     useSeekGhosting: true
-    youtubeSearchEnabled: true
+    ratelimit:
+      retryLimit: 5
 
 logging:
   level:
@@ -175,7 +176,7 @@ docker compose up -d
 
 ### No Self-Hosted Lavalink Required
 
-BeatDock can run **without a self-hosted Lavalink server**. If `LAVALINK_HOST`, `LAVALINK_PORT`, and `LAVALINK_PASSWORD` are not set, the bot automatically fetches free public Lavalink v4 servers and connects to one. If a public server goes down, it rotates to the next available node.
+BeatDock can run **without a self-hosted Lavalink server**. If `LAVALINK_HOST`, `LAVALINK_PORT`, and `LAVALINK_PASSWORD` are not set, the bot automatically fetches free public Lavalink v4 servers and connects to one. User search queries and track requests are sent to the selected public node. Set `PUBLIC_NODE_HOST_ALLOWLIST` if you only trust specific public Lavalink hosts.
 
 To use public servers, simply comment out the Lavalink variables in your `.env`:
 
@@ -217,12 +218,13 @@ All configuration is done through the `.env` file. Only `TOKEN` is required.
 | `SPOTIFY_ENABLED` | `false` | Enable Spotify search support |
 | `SPOTIFY_CLIENT_ID` | - | Spotify app client ID |
 | `SPOTIFY_CLIENT_SECRET` | - | Spotify app client secret |
-| `DEFAULT_LANGUAGE` | `en` | Bot language (`en`, `es`, `tr`, `it`, `pt-BR`) |
+| `DEFAULT_LANGUAGE` | `en` | Global bot language for this deployment (`en`, `es`, `tr`, `it`, `pt-BR`) |
 | `DEFAULT_VOLUME` | `80` | Default playback volume (0-100) |
 | `AUTOPLAY_DEFAULT` | `false` | Enable autoplay by default when music starts |
 | `ALLOWED_ROLES` | - | Comma-separated role IDs to restrict access |
 | `DEFAULT_SEARCH_PLATFORM` | `ytmsearch` | Default search platform for user queries | 
 | `LAVALINK_PASSWORD` | `youshallnotpass` | Lavalink server password |
+| `PUBLIC_NODE_HOST_ALLOWLIST` | - | Optional comma-separated host or `*.domain` allowlist for public Lavalink fallback |
 | `QUEUE_EMPTY_DESTROY_MS` | `30000` | Disconnect after queue empties (ms) |
 | `EMPTY_CHANNEL_DESTROY_MS` | `60000` | Disconnect from empty channel (ms) |
 

--- a/application.yml
+++ b/application.yml
@@ -48,7 +48,7 @@ lavalink:
       bandcamp: true
       twitch: true
       vimeo: true
-      http: true
+      http: false
       local: false
     bufferDurationMs: 200
     frameBufferDurationMs: 1000
@@ -56,13 +56,12 @@ lavalink:
     playerUpdateInterval: 2
     trackStuckThresholdMs: 5000
     useSeekGhosting: true
-    youtubeSearchEnabled: true
     ratelimit:
       ipBlocks: []
       excludedIps: []
       strategy: "RotateOnBan"
       searchTriggersFail: true
-      retryLimit: -1
+      retryLimit: 5
     filters:
       volume: true
       equalizer: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "5"
+
 services:
   bot:
     container_name: beatdock
@@ -11,6 +17,21 @@ services:
     networks:
       - beatdock-network
     env_file: .env
+    restart: unless-stopped
+    mem_limit: 512m
+    pids_limit: 256
+    cpus: "1.0"
+    logging: *default-logging
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "const fs=require('fs');const p=process.env.HEALTHCHECK_HEARTBEAT_PATH||'/tmp/beatdock-alive';try{const s=fs.statSync(p);process.exit(Date.now()-s.mtimeMs<120000?0:1)}catch{process.exit(1)}"
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 30s
 
   lavalink:
     container_name: beatdock-lavalink
@@ -18,14 +39,20 @@ services:
     networks:
       - beatdock-network
     volumes:
-      - ./application.yml:/opt/Lavalink/application.yml
+      - ./application.yml:/opt/Lavalink/application.yml:ro
     environment:
       - LAVALINK_PASSWORD=${LAVALINK_PASSWORD:-youshallnotpass}
       - SPOTIFY_ENABLED=${SPOTIFY_ENABLED:-false}
       - SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID:-}
       - SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET:-}
+      - JAVA_OPTS=-Xmx1g
+    restart: unless-stopped
+    mem_limit: 1.5g
+    pids_limit: 512
+    cpus: "2.0"
+    logging: *default-logging
     healthcheck:
-      test: ["CMD-SHELL", "bash -c 'echo > /dev/tcp/localhost/2333'"]
+      test: ["CMD", "/bin/bash", "-c", "echo > /dev/tcp/localhost/2333"]
       interval: 10s
       timeout: 5s
       retries: 5

--- a/locales/en.json
+++ b/locales/en.json
@@ -1,6 +1,7 @@
 {
     "NOT_IN_VOICE": "You must be in a voice channel to use this command.",
     "NO_RESULTS": "No results found for your query.",
+    "QUERY_NOT_ALLOWED": "That URL or query is not allowed for playback.",
     "NO_PERMISSION": "You don't have permission to use this bot.",
     "SONG_ADDED": "Added **{0}** to the queue.",
     "SONG_ADDED_NEXT": "Added **{0}** to play next.",

--- a/locales/es.json
+++ b/locales/es.json
@@ -1,6 +1,7 @@
 {
     "NOT_IN_VOICE": "Debes estar en un canal de voz para usar este comando.",
     "NO_RESULTS": "No se encontraron resultados para tu búsqueda.",
+    "QUERY_NOT_ALLOWED": "Esa URL o consulta no está permitida para la reproducción.",
     "NO_PERMISSION": "No tienes permiso para usar este bot.",
     "SONG_ADDED": "Añadido **{0}** a la cola.",
     "SONG_ADDED_NEXT": "Añadido **{0}** para reproducir a continuación.",

--- a/locales/it.json
+++ b/locales/it.json
@@ -1,6 +1,7 @@
 {
   "NOT_IN_VOICE": "Devi essere in un canale vocale per usare questo comando.",
   "NO_RESULTS": "Nessun risultato trovato per la tua ricerca.",
+  "QUERY_NOT_ALLOWED": "Questo URL o questa ricerca non è consentita per la riproduzione.",
   "NO_PERMISSION": "Non hai il permesso di usare questo bot.",
   "SONG_ADDED": "Aggiunto **{0}** alla coda.",
   "SONG_ADDED_NEXT": "Aggiunto **{0}** come prossimo brano.",

--- a/locales/pt-BR.json
+++ b/locales/pt-BR.json
@@ -1,6 +1,7 @@
 {
     "NOT_IN_VOICE": "Você precisa estar em um canal de voz para usar este comando.",
     "NO_RESULTS": "Sua consulta não retornou resultados.",
+    "QUERY_NOT_ALLOWED": "Essa URL ou consulta não é permitida para reprodução.",
     "NO_PERMISSION": "Você não tem permissão para usar este bot.",
     "SONG_ADDED": "**{0}** foi adicionado a fila.",
     "SONG_ADDED_NEXT": "**{0}** foi adicionado para tocar a seguir.",

--- a/locales/tr.json
+++ b/locales/tr.json
@@ -1,6 +1,7 @@
 {
     "NOT_IN_VOICE": "Bu komutu kullanmak için bir ses kanalında olmalısınız.",
     "NO_RESULTS": "Aradığın müzik için sonuç bulunamadı.",
+    "QUERY_NOT_ALLOWED": "Bu URL veya sorgunun oynatılmasına izin verilmiyor.",
     "NO_PERMISSION": "Bu botu kullanmak için yeterli izniniz yok.",
     "SONG_ADDED": "**{0}** kuyruğa eklendi.",
     "SONG_ADDED_NEXT": "**{0}** sıradaki olarak eklendi.",
@@ -101,4 +102,3 @@
     "FILTER_NONE_ACTIVE": "Aktif filtre yok.",
     "FILTER_SELECT": "Uygulamak veya kaldırmak için bir filtre seçin."
 }
-

--- a/src/commands/autoplay.js
+++ b/src/commands/autoplay.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { schedulePlayerUpdate } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -23,7 +24,7 @@ module.exports = {
             player.setRepeatMode('off');
         }
 
-        setTimeout(() => client.playerController.updatePlayer(guildId), 100);
+        schedulePlayerUpdate(client, guildId, 100);
 
         return interaction.reply({
             content: client.t(newState ? 'AUTOPLAY_ENABLED' : 'AUTOPLAY_DISABLED'),

--- a/src/commands/loop.js
+++ b/src/commands/loop.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
+const { schedulePlayerUpdate } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -24,7 +25,7 @@ module.exports = {
         // Cycle through loop modes: off -> track -> queue -> off
         let newMode;
         let modeMessage;
-        
+
         switch (player.repeatMode) {
             case 'off':
                 newMode = 'track';
@@ -47,10 +48,8 @@ module.exports = {
         player.setRepeatMode(newMode);
 
         // Update the player display
-        setTimeout(() => {
-            client.playerController.updatePlayer(interaction.guild.id);
-        }, 100);
+        schedulePlayerUpdate(client, interaction.guild.id, 100);
 
         return interaction.reply({ content: modeMessage, flags: MessageFlags.Ephemeral });
     },
-}; 
+};

--- a/src/commands/lyrics.js
+++ b/src/commands/lyrics.js
@@ -1,66 +1,55 @@
 const { SlashCommandBuilder, EmbedBuilder, MessageFlags } = require('discord.js');
 const { requirePlayer } = require('../utils/interactionHelpers');
+const { cleanArtist, cleanTitle, splitArtistFromTitle } = require('../utils/trackText');
 const { version } = require('../../package.json');
 const logger = require('../utils/logger');
 
-const TITLE_NOISE = /\s*[\(\[](official\s*(video|audio|music\s*video|lyric\s*video|visualizer)|lyric\s*video|lyrics?|audio|video|mv|hd|hq|4k|remaster(ed)?|live|ft\.?.*|feat\.?.*|prod\.?.*|visualizer)[\)\]]\s*/gi;
-const ARTIST_NOISE = /\s*(official\s*(youtube\s*)?channel|official|music|vevo|records?|entertainment)\s*/gi;
-const TOPIC_SUFFIX = /\s*-\s*Topic$/i;
 const MAX_EMBED_LENGTH = 4096;
-
-function splitArtistFromTitle(title, artist) {
-    // YouTube often formats as "Artist - Title" — split and use parts
-    const dashMatch = title.match(/^(.+?)\s*[-–—]\s+(.+)$/);
-    if (dashMatch) {
-        return { title: dashMatch[2], artist: dashMatch[1] };
-    }
-    return { title, artist };
-}
-
-function cleanTitle(title) {
-    return title.replace(TITLE_NOISE, '').trim();
-}
-
-function cleanArtist(artist) {
-    return artist
-        .replace(TOPIC_SUFFIX, '')
-        .replace(ARTIST_NOISE, ' ')
-        .replace(/\s+/g, ' ')
-        .trim();
-}
+const LYRICS_TIMEOUT_MS = 8000;
 
 async function fetchLyrics(title, artist, durationSec) {
-    const params = new URLSearchParams({
-        track_name: title,
-        artist_name: artist,
-    });
-    if (durationSec) params.set('duration', String(Math.round(durationSec)));
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), LYRICS_TIMEOUT_MS);
 
-    const response = await fetch(`https://lrclib.net/api/get?${params}`, {
-        headers: { 'User-Agent': `BeatDock/${version}` },
-    });
+    try {
+        const params = new URLSearchParams({
+            track_name: title,
+            artist_name: artist,
+        });
+        if (durationSec) params.set('duration', String(Math.round(durationSec)));
 
-    if (response.ok) {
-        const data = await response.json();
-        if (data && (data.plainLyrics || data.syncedLyrics || data.instrumental)) {
-            return data;
+        const response = await fetch(`https://lrclib.net/api/get?${params}`, {
+            headers: { 'User-Agent': `BeatDock/${version}` },
+            signal: controller.signal,
+        });
+
+        if (response.ok) {
+            const data = await response.json();
+            if (data && (data.plainLyrics || data.syncedLyrics || data.instrumental)) {
+                return data;
+            }
         }
-    }
 
-    // Fallback: search endpoint
-    const searchResponse = await fetch(
-        `https://lrclib.net/api/search?q=${encodeURIComponent(`${title} ${artist}`)}`,
-        { headers: { 'User-Agent': `BeatDock/${version}` } }
-    );
+        // Fallback: search endpoint
+        const searchResponse = await fetch(
+            `https://lrclib.net/api/search?q=${encodeURIComponent(`${title} ${artist}`)}`,
+            {
+                headers: { 'User-Agent': `BeatDock/${version}` },
+                signal: controller.signal,
+            }
+        );
 
-    if (searchResponse.ok) {
-        const results = await searchResponse.json();
-        if (Array.isArray(results) && results.length > 0) {
-            return results[0];
+        if (searchResponse.ok) {
+            const results = await searchResponse.json();
+            if (Array.isArray(results) && results.length > 0) {
+                return results[0];
+            }
         }
-    }
 
-    return null;
+        return null;
+    } finally {
+        clearTimeout(timeout);
+    }
 }
 
 module.exports = {

--- a/src/commands/play.js
+++ b/src/commands/play.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const { isLavalinkAvailable, handleLavalinkError } = require('../utils/interactionHelpers');
+const { validatePlaybackQuery } = require('../utils/queryGuard');
 const { getValidVolume } = require('../utils/volumeValidator');
 const logger = require('../utils/logger');
 
@@ -26,6 +27,14 @@ module.exports = {
         try {
             if (!voiceChannel) {
                 return await interaction.reply({ content: client.languageManager.get(lang, 'NOT_IN_VOICE'), flags: MessageFlags.Ephemeral });
+            }
+
+            const querySafety = await validatePlaybackQuery(query);
+            if (!querySafety.allowed) {
+                return await interaction.reply({
+                    content: client.languageManager.get(lang, 'QUERY_NOT_ALLOWED'),
+                    flags: MessageFlags.Ephemeral
+                });
             }
 
             // Check if Lavalink is available

--- a/src/commands/search.js
+++ b/src/commands/search.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const searchSessions = require('../utils/searchSessions');
 const { isLavalinkAvailable, handleLavalinkError } = require('../utils/interactionHelpers');
 const { createSearchEmbed, createSearchComponents } = require('../utils/embeds');
+const { validatePlaybackQuery } = require('../utils/queryGuard');
 const { getValidVolume } = require('../utils/volumeValidator');
 const logger = require('../utils/logger');
 
@@ -57,6 +58,14 @@ module.exports = {
             if (query.length > 200) {
                 return await interaction.reply({
                     content: client.languageManager.get(lang, 'SEARCH_QUERY_TOO_LONG'),
+                    flags: MessageFlags.Ephemeral
+                });
+            }
+
+            const querySafety = await validatePlaybackQuery(query);
+            if (!querySafety.allowed) {
+                return await interaction.reply({
+                    content: client.languageManager.get(lang, 'QUERY_NOT_ALLOWED'),
                     flags: MessageFlags.Ephemeral
                 });
             }

--- a/src/commands/shuffle.js
+++ b/src/commands/shuffle.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const { requirePlayer } = require('../utils/interactionHelpers');
 const { shuffleQueue } = require('../utils/PlayerActions');
+const { schedulePlayerUpdate } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -25,13 +26,11 @@ module.exports = {
         shuffleQueue(player);
 
         // Update the player display
-        setTimeout(() => {
-            client.playerController.updatePlayer(interaction.guild.id);
-        }, 100);
+        schedulePlayerUpdate(client, interaction.guild.id, 100);
 
-        return interaction.reply({ 
+        return interaction.reply({
             content: client.languageManager.get(client.defaultLanguage, 'QUEUE_SHUFFLED'),
             flags: MessageFlags.Ephemeral
         });
     },
-}; 
+};

--- a/src/commands/stop.js
+++ b/src/commands/stop.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const { requirePlayer } = require('../utils/interactionHelpers');
+const { clearGuildLifecycleTimers } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -15,10 +16,11 @@ module.exports = {
         logger.cmd(`/stop by ${interaction.user.tag} in #${interaction.channel.name} (Guild: ${interaction.guild.name})`);
 
         client.autoplayEnabled.delete(interaction.guild.id);
+        clearGuildLifecycleTimers(interaction.guild.id);
         await player.destroy();
-        return interaction.reply({ 
+        return interaction.reply({
             content: client.languageManager.get(client.defaultLanguage, 'STOPPED_PLAYBACK'),
             flags: MessageFlags.Ephemeral
         });
     },
-}; 
+};

--- a/src/commands/volume.js
+++ b/src/commands/volume.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder, MessageFlags } = require('discord.js');
 const { requirePlayer } = require('../utils/interactionHelpers');
+const { schedulePlayerUpdate } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 module.exports = {
@@ -26,13 +27,11 @@ module.exports = {
         player.setVolume(volume);
 
         // Update the player display
-        setTimeout(() => {
-            client.playerController.updatePlayer(interaction.guild.id);
-        }, 100);
+        schedulePlayerUpdate(client, interaction.guild.id, 100);
 
-        return interaction.reply({ 
+        return interaction.reply({
             content: client.languageManager.get(client.defaultLanguage, 'VOLUME_SET', volume),
             flags: MessageFlags.Ephemeral
         });
     },
-}; 
+};

--- a/src/events/guildDelete.js
+++ b/src/events/guildDelete.js
@@ -1,6 +1,7 @@
 const { Events } = require('discord.js');
 const searchSessions = require('../utils/searchSessions');
 const { emptyChannelTimeouts } = require('./voiceStateUpdate');
+const { clearGuildLifecycleTimers } = require('../utils/playerLifecycle');
 
 module.exports = {
     name: Events.GuildDelete,
@@ -10,6 +11,7 @@ module.exports = {
 
         // Clean up Lavalink player and controller message
         const player = client.lavalink.getPlayer(guildId);
+        clearGuildLifecycleTimers(guildId);
         if (player) player.destroy();
         client.playerController.deletePlayer(guildId);
 

--- a/src/events/interactionCreate.js
+++ b/src/events/interactionCreate.js
@@ -4,6 +4,7 @@ const { handleSearchNavigation } = require('../interactions/searchNavigation');
 const { handleFilterNavigation } = require('../interactions/filterNavigation');
 const { requirePlayer, requireSameVoice } = require('../utils/interactionHelpers');
 const { playPrevious, shuffleQueue, clearQueue, jumpToTrack, createPaginatedQueueResponse } = require('../utils/PlayerActions');
+const { clearGuildLifecycleTimers, schedulePlayerUpdate } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 async function handlePlayerInteraction(interaction, action) {
@@ -52,6 +53,7 @@ async function handlePlayerInteraction(interaction, action) {
         }
         case 'stop': {
             client.autoplayEnabled.delete(interaction.guild.id);
+            clearGuildLifecycleTimers(interaction.guild.id);
             await player.destroy();
             await interaction.reply({ content: client.languageManager.get(lang, 'STOPPED_PLAYBACK'), flags: MessageFlags.Ephemeral });
             break;
@@ -107,7 +109,7 @@ async function handlePlayerInteraction(interaction, action) {
     }
 
     if (action !== 'stop') {
-        setTimeout(() => client.playerController.updatePlayer(interaction.guild.id).catch(() => {}), 500);
+        schedulePlayerUpdate(client, interaction.guild.id, 500);
     }
 }
 
@@ -168,7 +170,7 @@ async function handleQueueInteraction(interaction, action, args) {
                 flags: MessageFlags.Ephemeral
             });
 
-            setTimeout(() => client.playerController.updatePlayer(interaction.guild.id).catch(() => {}), 500);
+            schedulePlayerUpdate(client, interaction.guild.id, 500);
             break;
         }
     }
@@ -281,4 +283,4 @@ module.exports = {
             await handleSelectMenuInteraction(interaction);
         }
     },
-}; 
+};

--- a/src/events/voiceStateUpdate.js
+++ b/src/events/voiceStateUpdate.js
@@ -1,5 +1,6 @@
 const { Events } = require('discord.js');
 const searchSessions = require('../utils/searchSessions');
+const { clearGuildLifecycleTimers } = require('../utils/playerLifecycle');
 
 // Keep track of disconnect timers per guild
 const emptyChannelTimeouts = new Map();
@@ -20,12 +21,13 @@ module.exports = {
 
                 // Clean up Lavalink player and controller message
                 const player = client.lavalink.getPlayer(guildId);
+                clearGuildLifecycleTimers(guildId);
                 if (player) player.destroy();
                 client.playerController.deletePlayer(guildId);
-                
+
                 // Clean up search sessions for this guild
                 searchSessions.cleanupGuildSessions(guildId);
-                
+
                 // Update presence
                 client.activePlayers.delete(guildId);
                 client.autoplayEnabled.delete(guildId);
@@ -77,12 +79,13 @@ module.exports = {
 
                     // Destroy player and cleanup
                     const player = client.lavalink.getPlayer(guildId);
+                    clearGuildLifecycleTimers(guildId);
                     if (player) player.destroy();
                     client.playerController.deletePlayer(guildId);
-                    
+
                     // Clean up search sessions for this guild
                     searchSessions.cleanupGuildSessions(guildId);
-                    
+
                     // Update presence
                     client.activePlayers.delete(guildId);
                     client.autoplayEnabled.delete(guildId);
@@ -99,4 +102,4 @@ module.exports = {
             }
         }
     },
-}; 
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 require('dotenv').config();
+const fs = require('fs');
 const { Client, GatewayIntentBits, ActivityType } = require('discord.js');
 const { LavalinkManager } = require('lavalink-client');
 const LanguageManager = require('./LanguageManager');
@@ -7,12 +8,23 @@ const LavalinkConnectionManager = require('./utils/LavalinkConnectionManager');
 const PublicNodeProvider = require('./utils/PublicNodeProvider');
 const searchSessions = require('./utils/searchSessions');
 const { findAutoplayTracks } = require('./utils/autoplay');
+const {
+    clearQueueEndTimeout,
+    setQueueEndTimeout,
+    clearAllQueueEndTimeouts,
+    clearAllPlayerUpdates,
+    clearGuildLifecycleTimers,
+    schedulePlayerUpdate,
+} = require('./utils/playerLifecycle');
 const loadCommands = require('./handlers/commandHandler');
 const registerEvents = require('./handlers/eventHandler');
 const logger = require('./utils/logger');
 
 const AUTOPLAY_TIMEOUT_MS = 5000;
 const TRACK_END_CLEANUP_DELAY_MS = 500;
+const SHUTDOWN_TIMEOUT_MS = 5000;
+const HEALTHCHECK_HEARTBEAT_PATH = process.env.HEALTHCHECK_HEARTBEAT_PATH || '/tmp/beatdock-alive';
+const HEALTHCHECK_HEARTBEAT_INTERVAL_MS = 30000;
 
 function isLocalLavalinkConfigured() {
     const host = process.env.LAVALINK_HOST;
@@ -92,7 +104,21 @@ function createClient() {
     return client;
 }
 
+function writeHealthcheckHeartbeat() {
+    fs.writeFile(HEALTHCHECK_HEARTBEAT_PATH, String(Date.now()), (error) => {
+        if (error) {
+            logger.debug('Failed to write healthcheck heartbeat:', error.message);
+        }
+    });
+}
+
+function startHealthcheckHeartbeat() {
+    writeHealthcheckHeartbeat();
+    return setInterval(writeHealthcheckHeartbeat, HEALTHCHECK_HEARTBEAT_INTERVAL_MS);
+}
+
 function cleanupGuildPlayer(client, guildId) {
+    clearGuildLifecycleTimers(guildId);
     client.playerController.deletePlayer(guildId);
     client.activePlayers.delete(guildId);
     client.autoplayEnabled.delete(guildId);
@@ -153,20 +179,15 @@ async function setupLavalink(client) {
 }
 
 function registerLavalinkEvents(client) {
-    const queueEndTimeouts = new Map();
-
     client.lavalink.on("trackStart", (player, track) => {
-        if (queueEndTimeouts.has(player.guildId)) {
-            clearTimeout(queueEndTimeouts.get(player.guildId));
-            queueEndTimeouts.delete(player.guildId);
-        }
+        clearQueueEndTimeout(player.guildId);
 
         if (!client.autoplayEnabled.has(player.guildId)) {
             const autoplayDefault = process.env.AUTOPLAY_DEFAULT === 'true';
             client.autoplayEnabled.set(player.guildId, autoplayDefault);
         }
 
-        client.playerController.updatePlayer(player.guildId);
+        schedulePlayerUpdate(client, player.guildId, 0);
 
         client.activePlayers.set(player.guildId, {
             title: track.info?.title,
@@ -183,7 +204,7 @@ function registerLavalinkEvents(client) {
 
         setTimeout(() => {
             if (player.queue.current) {
-                client.playerController.updatePlayer(player.guildId);
+                schedulePlayerUpdate(client, player.guildId, 0);
             } else if (!client.autoplayEnabled.get(player.guildId)) {
                 cleanupGuildPlayer(client, player.guildId);
             }
@@ -193,14 +214,11 @@ function registerLavalinkEvents(client) {
     client.lavalink.on("queueEnd", (player) => {
         const guildId = player.guildId;
 
-        if (queueEndTimeouts.has(guildId)) {
-            clearTimeout(queueEndTimeouts.get(guildId));
-            queueEndTimeouts.delete(guildId);
-        }
+        clearQueueEndTimeout(guildId);
 
         if (client.autoplayEnabled.get(guildId)) {
             const timeout = setTimeout(() => {
-                queueEndTimeouts.delete(guildId);
+                clearQueueEndTimeout(guildId);
 
                 const currentPlayer = client.lavalink.getPlayer(guildId);
                 if (currentPlayer?.queue.current || currentPlayer?.playing) return;
@@ -214,7 +232,7 @@ function registerLavalinkEvents(client) {
                 }
                 cleanupGuildPlayer(client, guildId);
             }, AUTOPLAY_TIMEOUT_MS);
-            queueEndTimeouts.set(guildId, timeout);
+            setQueueEndTimeout(guildId, timeout);
             return;
         }
 
@@ -242,23 +260,32 @@ function setupShutdown(client) {
         logger.info(`Received ${signal}, shutting down gracefully...`);
 
         client.lavalinkConnectionManager.destroy();
+        clearAllQueueEndTimeouts();
+        clearAllPlayerUpdates();
 
-        if (client.publicNodeProvider) {
-            client.publicNodeProvider.destroy();
+        if (client.healthcheckHeartbeat) {
+            clearInterval(client.healthcheckHeartbeat);
+            client.healthcheckHeartbeat = null;
         }
+
+        client.publicNodeProvider?.destroy();
 
         searchSessions.destroy();
 
-        // Destroy all players before destroying nodes
-        for (const player of client.lavalink.players.values()) {
-            await player.destroy();
-        }
+        const shutdownWork = (async () => {
+            await Promise.allSettled([...client.lavalink.players.values()].map(player => player.destroy()));
+            await Promise.allSettled([...client.lavalink.nodeManager.nodes.values()].map(node => node.destroy()));
+            await client.destroy();
+        })();
 
-        for (const node of client.lavalink.nodeManager.nodes.values()) {
-            await node.destroy();
-        }
+        const result = await Promise.race([
+            shutdownWork.then(() => 'complete'),
+            new Promise(resolve => setTimeout(() => resolve('timeout'), SHUTDOWN_TIMEOUT_MS)),
+        ]);
 
-        await client.destroy();
+        if (result === 'timeout') {
+            logger.warn(`Graceful shutdown exceeded ${SHUTDOWN_TIMEOUT_MS}ms deadline; exiting`);
+        }
 
         process.exit(0);
     };
@@ -275,6 +302,7 @@ async function bootstrap() {
     registerEvents(client);
     setupShutdown(client);
     await client.login(process.env.TOKEN);
+    client.healthcheckHeartbeat = startHealthcheckHeartbeat();
 }
 
 process.on('unhandledRejection', (error) => {

--- a/src/interactions/searchNavigation.js
+++ b/src/interactions/searchNavigation.js
@@ -3,6 +3,7 @@ const searchSessions = require('../utils/searchSessions');
 const { isLavalinkAvailable } = require('../utils/interactionHelpers');
 const { createSearchEmbed, createSearchComponents } = require('../utils/embeds');
 const { getValidVolume } = require('../utils/volumeValidator');
+const { clearGuildLifecycleTimers, schedulePlayerUpdate } = require('../utils/playerLifecycle');
 const logger = require('../utils/logger');
 
 async function handleSearchNavigation(interaction) {
@@ -106,7 +107,7 @@ async function handleSearchNavigation(interaction) {
                         // Send or update the player controller
                         const existingMessageId = client.playerController.playerMessages.get(guild.id);
                         if (existingMessageId) {
-                            setTimeout(() => client.playerController.updatePlayer(guild.id).catch(() => {}), 100);
+                            schedulePlayerUpdate(client, guild.id, 100);
                         } else {
                             // Get the text channel to send the player UI
                             const textChannel = await client.channels.fetch(session.textChannelId).catch(() => null);
@@ -134,6 +135,7 @@ async function handleSearchNavigation(interaction) {
                 const existingPlayer = client.lavalink.getPlayer(guild.id);
                 if (existingPlayer && !existingPlayer.connected && !existingPlayer.playing) {
                     client.autoplayEnabled.delete(guild.id);
+                    clearGuildLifecycleTimers(guild.id);
                     existingPlayer.destroy();
                 }
 

--- a/src/utils/LavalinkConnectionManager.js
+++ b/src/utils/LavalinkConnectionManager.js
@@ -50,14 +50,14 @@ class LavalinkConnectionManager {
         if (this.state.healthCheckInterval) {
             clearInterval(this.state.healthCheckInterval);
         }
-        
+
         const healthCheckInterval = parseInt(process.env.LAVALINK_HEALTH_CHECK_INTERVAL_MS || "30000", 10);
         let lastHealthStatus = true; // Track if we were healthy last time
-        
+
         this.state.healthCheckInterval = setInterval(() => {
             const mainNode = this.client.lavalink.nodeManager.nodes.get('main-node');
             const isCurrentlyHealthy = mainNode && mainNode.connected;
-            
+
             if (!isCurrentlyHealthy) {
                 logger.warn('Health check: Node not connected, attempting reconnection...');
                 lastHealthStatus = false;
@@ -86,11 +86,11 @@ class LavalinkConnectionManager {
         if (this.state.periodicResetInterval) {
             clearInterval(this.state.periodicResetInterval);
         }
-        
+
         this.state.periodicResetInterval = setInterval(() => {
             const mainNode = this.client.lavalink.nodeManager.nodes.get('main-node');
             const timeSinceLastPing = Date.now() - this.state.lastPing;
-            
+
             if (!mainNode || !mainNode.connected || timeSinceLastPing > PING_TIMEOUT_MS) {
                 logger.debug('Periodic reset: No recent connection activity, attempting reconnection...');
                 this.state.reconnectAttempts = 0; // Reset attempts
@@ -147,11 +147,12 @@ class LavalinkConnectionManager {
         }
 
         this.state.isReconnecting = true;
+        let keepReconnectLock = false;
         logger.debug('Starting Lavalink reconnection process...');
-        
+
         try {
             const mainNode = this.client.lavalink.nodeManager.nodes.get('main-node');
-            
+
             if (mainNode && mainNode.connected) {
                 logger.debug('Node is already connected, skipping reconnection');
                 this.state.isReconnecting = false;
@@ -164,7 +165,7 @@ class LavalinkConnectionManager {
                 try {
                     await mainNode.destroy();
                 } catch (error) {
-                    logger.debug('Error destroying existing node:', error.message);
+                    logger.debug('Error destroying existing node:', error?.message || error);
                 }
             }
 
@@ -181,12 +182,12 @@ class LavalinkConnectionManager {
             } catch (error) {
                 throw new Error(`Failed to create node: ${error.message}`);
             }
-            
+
             // Validate the created node
             if (!newNode) {
                 throw new Error('Node creation failed - no node object returned');
             }
-            
+
             // Wait for connection with proper error handling
             await new Promise((resolve, reject) => {
                 const timeout = setTimeout(() => {
@@ -197,7 +198,7 @@ class LavalinkConnectionManager {
                     }
                     reject(new Error('Connection timeout'));
                 }, CONNECTION_TIMEOUT_MS);
-                
+
                 const onConnect = () => {
                     clearTimeout(timeout);
                     // Clean up event listeners on success
@@ -207,7 +208,7 @@ class LavalinkConnectionManager {
                     }
                     resolve();
                 };
-                
+
                 const onError = (error) => {
                     clearTimeout(timeout);
                     // Clean up event listeners on error
@@ -217,7 +218,7 @@ class LavalinkConnectionManager {
                     }
                     reject(error);
                 };
-                
+
                 // Check if the node has the event methods
                 if (typeof newNode.once === 'function') {
                     newNode.once('connect', onConnect);
@@ -235,13 +236,13 @@ class LavalinkConnectionManager {
                     }, 2000);
                 }
             });
-            
+
             logger.info('Lavalink reconnection successful');
             this.state.reconnectAttempts = 0;
             this.state.isReconnecting = false;
 
         } catch (error) {
-            logger.error('Reconnection attempt failed:', error.message);
+            logger.error('Reconnection attempt failed:', error?.message || error);
             this.state.reconnectAttempts++;
 
             if (this.state.reconnectAttempts >= this.state.maxReconnectAttempts) {
@@ -273,6 +274,11 @@ class LavalinkConnectionManager {
                 this.state.isReconnecting = false;
                 this.attemptReconnection();
             }, delay);
+            keepReconnectLock = true;
+        } finally {
+            if (!keepReconnectLock) {
+                this.state.isReconnecting = false;
+            }
         }
     }
 
@@ -308,13 +314,14 @@ class LavalinkConnectionManager {
         if (!this.state.isInitialized) {
             return;
         }
-        
+
         // Only log errors if we've had a successful connection before
         if (this.state.hasHadSuccessfulConnection) {
             logger.error('Lavalink node encountered an error:', error);
 
             // Only trigger reconnection for connection-related errors
-            if (error.code === 'ECONNREFUSED' || error.code === 'ENOTFOUND' || error.message.includes('Unable to connect')) {
+            const message = error?.message || '';
+            if (error?.code === 'ECONNREFUSED' || error?.code === 'ENOTFOUND' || message.includes('Unable to connect')) {
                 logger.debug('Connection error detected, will attempt reconnection...');
                 setTimeout(() => this.attemptReconnection(), RECONNECT_DELAY_ON_ERROR_MS);
             }
@@ -326,10 +333,11 @@ class LavalinkConnectionManager {
         if (!this.state.isInitialized) {
             return;
         }
-        
+
         // Only log disconnects if we've had a successful connection before
         if (this.state.hasHadSuccessfulConnection) {
-            logger.warn(`Lavalink node disconnected (reason: ${reason.reason || 'Unknown'})`);
+            const reasonText = reason?.reason || 'Unknown';
+            logger.warn(`Lavalink node disconnected (reason: ${reasonText})`);
 
             // Clear health check interval
             if (this.state.healthCheckInterval) {
@@ -344,16 +352,16 @@ class LavalinkConnectionManager {
             }
 
             // Attempt reconnection for unexpected disconnections
-            if (reason.reason !== 'destroy') {
+            if (reasonText !== 'destroy') {
                 logger.info('Unexpected disconnection, attempting reconnection...');
 
                 // Different handling based on disconnect reason
                 let delay = 2000; // Default 2 seconds
 
-                if (reason.reason === 'Socket got terminated due to no ping connection') {
-                    logger.debug('No ping connection detected — possible network issue');
+                if (reasonText === 'Socket got terminated due to no ping connection') {
+                    logger.debug('No ping connection detected - possible network issue');
                     delay = 5000; // Wait 5 seconds for network issues
-                } else if (reason.reason.includes('timeout')) {
+                } else if (typeof reasonText === 'string' && reasonText.includes('timeout')) {
                     logger.debug('Connection timeout detected');
                     delay = 3000; // Wait 3 seconds for timeouts
                 }
@@ -369,7 +377,7 @@ class LavalinkConnectionManager {
     initialize() {
         logger.info('Lavalink connection manager initializing...');
         this.state.isInitialized = true;
-        
+
         // Start monitoring immediately
         this.startMonitoring();
     }
@@ -378,7 +386,7 @@ class LavalinkConnectionManager {
     startMonitoring() {
         // Check immediately
         this.checkAndStartHealthChecks();
-        
+
         // Then check every 5 seconds until we get a connection
         const monitoringInterval = setInterval(() => {
             if (this.isAvailable()) {
@@ -433,4 +441,4 @@ class LavalinkConnectionManager {
 
 }
 
-module.exports = LavalinkConnectionManager; 
+module.exports = LavalinkConnectionManager;

--- a/src/utils/PlayerController.js
+++ b/src/utils/PlayerController.js
@@ -1,6 +1,12 @@
 const { ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder } = require('discord.js');
 const { formatDuration } = require('./embeds');
+const { truncateText } = require('./trackSelectMenu');
 const logger = require('./logger');
+
+const EMBED_TITLE_LIMIT = 256;
+const EMBED_DESCRIPTION_LIMIT = 4096;
+const EMBED_FIELD_VALUE_LIMIT = 1024;
+const EMBED_FOOTER_LIMIT = 2048;
 
 class PlayerController {
     constructor(client) {
@@ -10,13 +16,23 @@ class PlayerController {
 
     createPlayerEmbed(player, track) {
         const lang = this.client.defaultLanguage;
+        const title = truncateText(track.info?.title || 'Unknown', EMBED_TITLE_LIMIT);
+        const uri = typeof track.info?.uri === 'string' && track.info.uri.length <= 2048
+            ? track.info.uri
+            : null;
+        const trackLabel = uri ? `[${title}](${uri})` : title;
+        const nowPlaying = this.client.languageManager.get(lang, 'PLAYER_NOW_PLAYING');
+        const description = truncateText(`**${nowPlaying}:**\n${trackLabel}`, EMBED_DESCRIPTION_LIMIT);
+        const artist = truncateText(track.info?.author || 'Unknown', EMBED_FIELD_VALUE_LIMIT);
+        const volumeFooter = truncateText(this.client.languageManager.get(lang, 'PLAYER_VOLUME', player.volume), EMBED_FOOTER_LIMIT);
+
         const embed = new EmbedBuilder()
             .setColor(0x0099FF)
             .setTitle(this.client.languageManager.get(lang, 'PLAYER_TITLE'))
-            .setDescription(`**${this.client.languageManager.get(lang, 'PLAYER_NOW_PLAYING')}:**\n[${track.info?.title || 'Unknown'}](${track.info?.uri || '#'})`)
+            .setDescription(description)
             .setThumbnail(track.info?.artworkUrl || null)
             .addFields(
-                { name: this.client.languageManager.get(lang, 'PLAYER_ARTIST'), value: track.info?.author || 'Unknown', inline: true },
+                { name: this.client.languageManager.get(lang, 'PLAYER_ARTIST'), value: artist, inline: true },
                 { name: this.client.languageManager.get(lang, 'PLAYER_DURATION'), value: formatDuration(track.info?.duration || 0), inline: true },
                 { name: this.client.languageManager.get(lang, 'PLAYER_QUEUE_COUNT'), value: this.client.languageManager.get(lang, 'PLAYER_SONGS_COUNT', player.queue.tracks.length), inline: true },
                 ...(track.userData?.autoplay
@@ -25,7 +41,7 @@ class PlayerController {
                         ? [{ name: this.client.languageManager.get(lang, 'PLAYER_REQUESTED_BY'), value: `<@${track.userData.requester.id}>`, inline: true }]
                         : [])
             )
-            .setFooter({ text: this.client.languageManager.get(lang, 'PLAYER_VOLUME', player.volume) })
+            .setFooter({ text: volumeFooter })
             .setTimestamp();
 
         // Add loop status to the embed
@@ -35,15 +51,15 @@ class PlayerController {
                 ? this.client.languageManager.get(lang, 'LOOP_STATUS_TRACK')
                 : this.client.languageManager.get(lang, 'LOOP_STATUS_QUEUE');
             embed.setFooter({
-                text: `${this.client.languageManager.get(lang, 'PLAYER_VOLUME', player.volume)} | ${loopIcon} ${loopText}`
+                text: truncateText(`${volumeFooter} | ${loopIcon} ${loopText}`, EMBED_FOOTER_LIMIT)
             });
         }
 
         // Add autoplay status to the embed
         if (this.client.autoplayEnabled.get(player.guildId)) {
             const autoplayText = this.client.languageManager.get(lang, 'AUTOPLAY_STATUS');
-            const currentFooter = embed.data.footer?.text || this.client.languageManager.get(lang, 'PLAYER_VOLUME', player.volume);
-            embed.setFooter({ text: `${currentFooter} | 📻 ${autoplayText}` });
+            const currentFooter = embed.data.footer?.text || volumeFooter;
+            embed.setFooter({ text: truncateText(`${currentFooter} | 📻 ${autoplayText}`, EMBED_FOOTER_LIMIT) });
         }
 
         return embed;
@@ -52,7 +68,7 @@ class PlayerController {
     createPlayerButtons(player) {
         const isPaused = player.paused;
         const loopIcon = player.repeatMode === 'track' ? '🔂' : player.repeatMode === 'queue' ? '🔁' : '➡️';
-        
+
         const row1 = new ActionRowBuilder()
             .addComponents(
                 new ButtonBuilder()
@@ -126,7 +142,7 @@ class PlayerController {
                 || await channel.messages.fetch(playerMessage.messageId);
             const embed = this.createPlayerEmbed(player, player.queue.current);
             const components = this.createPlayerButtons(player);
-            
+
             await message.edit({ embeds: [embed], components });
         } catch (error) {
             logger.error('Error updating player:', error);
@@ -153,4 +169,4 @@ class PlayerController {
 
 }
 
-module.exports = PlayerController; 
+module.exports = PlayerController;

--- a/src/utils/PlayerController.js
+++ b/src/utils/PlayerController.js
@@ -28,7 +28,7 @@ class PlayerController {
 
         const embed = new EmbedBuilder()
             .setColor(0x0099FF)
-            .setTitle(this.client.languageManager.get(lang, 'PLAYER_TITLE'))
+            .setTitle(truncateText(this.client.languageManager.get(lang, 'PLAYER_TITLE'), EMBED_TITLE_LIMIT))
             .setDescription(description)
             .setThumbnail(track.info?.artworkUrl || null)
             .addFields(

--- a/src/utils/PublicNodeProvider.js
+++ b/src/utils/PublicNodeProvider.js
@@ -1,8 +1,40 @@
 const logger = require('./logger');
+const { isSafeExternalHost, normalizeHost, parseHostAllowlist } = require('./networkGuard');
 
 const API_URL = 'https://lavalink-list.ajieblogs.eu.org/All';
 const REFRESH_INTERVAL_MS = 10 * 60 * 1000; // 10 minutes (matches API refresh)
 const FETCH_TIMEOUT_MS = 10000;
+const MAX_RESPONSE_BYTES = 256 * 1024;
+const MAX_HOST_LENGTH = 253;
+const MAX_PASSWORD_LENGTH = 512;
+
+async function readResponseTextWithLimit(response) {
+    if (!response.body?.getReader) {
+        const text = await response.text();
+        if (Buffer.byteLength(text, 'utf8') > MAX_RESPONSE_BYTES) {
+            throw new Error('Public node API response exceeded size limit');
+        }
+        return text;
+    }
+
+    const reader = response.body.getReader();
+    const chunks = [];
+    let totalBytes = 0;
+
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+
+        totalBytes += value.byteLength;
+        if (totalBytes > MAX_RESPONSE_BYTES) {
+            await reader.cancel();
+            throw new Error('Public node API response exceeded size limit');
+        }
+        chunks.push(Buffer.from(value));
+    }
+
+    return Buffer.concat(chunks).toString('utf8');
+}
 
 class PublicNodeProvider {
     constructor() {
@@ -12,22 +44,23 @@ class PublicNodeProvider {
     }
 
     async fetchNodes() {
+        let timeout;
         try {
             const controller = new AbortController();
-            const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+            timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
             const response = await fetch(API_URL, { signal: controller.signal });
-            clearTimeout(timeout);
 
             if (!response.ok) {
                 throw new Error(`API returned ${response.status}`);
             }
 
-            const data = await response.json();
+            const text = await readResponseTextWithLimit(response);
+            const data = JSON.parse(text);
             if (!Array.isArray(data)) throw new Error('Unexpected API response format');
-            const allV4Nodes = data.filter(node =>
-                node.version === 'v4' && node.host && node.port && node.password
-            );
+            const allowlist = parseHostAllowlist();
+            const checkedNodes = await Promise.all(data.map(node => this.validateNode(node, allowlist)));
+            const allV4Nodes = checkedNodes.filter(Boolean);
             const secureNodes = allV4Nodes.filter(node => node.secure === true);
             const v4Nodes = secureNodes.length > 0 ? secureNodes : allV4Nodes;
             if (secureNodes.length === 0 && allV4Nodes.length > 0) {
@@ -41,7 +74,7 @@ class PublicNodeProvider {
 
             this.nodes = v4Nodes;
             this.currentIndex = 0;
-            logger.info(`Fetched ${v4Nodes.length} public Lavalink v4 nodes`);
+            logger.info(`Fetched ${v4Nodes.length} validated public Lavalink v4 nodes`);
             return true;
         } catch (error) {
             if (this.nodes.length > 0) {
@@ -50,7 +83,39 @@ class PublicNodeProvider {
             }
             logger.error('Failed to fetch public Lavalink nodes:', error.message);
             return false;
+        } finally {
+            clearTimeout(timeout);
         }
+    }
+
+    async validateNode(node, allowlist) {
+        if (!node || typeof node !== 'object') return null;
+        if (node.version !== 'v4') return null;
+
+        const host = normalizeHost(node.host);
+        const port = Number(node.port);
+        const password = typeof node.password === 'string' ? node.password.trim() : '';
+        const secure = node.secure === true;
+
+        if (!host || host.length > MAX_HOST_LENGTH) return null;
+        if (!Number.isInteger(port) || port < 1 || port > 65535) return null;
+        if (!password || password.length > MAX_PASSWORD_LENGTH) return null;
+
+        try {
+            const safeHost = await isSafeExternalHost(host, { allowlist });
+            if (!safeHost) return null;
+        } catch (error) {
+            logger.debug(`Rejected public Lavalink node ${host}:${port}: ${error.message}`);
+            return null;
+        }
+
+        return {
+            version: 'v4',
+            host,
+            port,
+            password,
+            secure,
+        };
     }
 
     getNextNode() {

--- a/src/utils/autoplay.js
+++ b/src/utils/autoplay.js
@@ -3,26 +3,7 @@
 // Tier 2: Smart search rotation via YouTube Music
 // Tier 3: Relaxed dedup last resort
 
-function normalizeString(str) {
-    return str
-        .toLowerCase()
-        .replace(/\(official\s*(music\s*)?video\)/gi, '')
-        .replace(/\((lyrics?|audio|official\s*audio|visualizer|hd|hq)\)/gi, '')
-        .replace(/\[.*?\]/g, '')
-        .replace(/\s*-\s*topic$/gi, '')
-        .replace(/vevo$/gi, '')
-        .replace(/[^\w\s]/g, '')
-        .replace(/\s+/g, ' ')
-        .trim();
-}
-
-function cleanAuthor(author) {
-    return author
-        .replace(/vevo$/i, '')
-        .replace(/\s*-\s*topic$/i, '')
-        .replace(/official$/i, '')
-        .trim();
-}
+const { cleanAuthor, normalizeString } = require('./trackText');
 
 function getRecentIdentifiers(player) {
     const ids = new Set();

--- a/src/utils/networkGuard.js
+++ b/src/utils/networkGuard.js
@@ -1,0 +1,167 @@
+const dns = require('dns').promises;
+const net = require('net');
+
+const DNS_LOOKUP_TIMEOUT_MS = 3000;
+const BLOCKED_HOST_SUFFIXES = [
+    '.localhost',
+    '.local',
+    '.internal',
+    '.lan',
+    '.home',
+    '.corp',
+];
+
+function normalizeHost(host) {
+    return String(host || '')
+        .trim()
+        .replace(/^\[(.*)\]$/, '$1')
+        .replace(/\.$/, '')
+        .toLowerCase();
+}
+
+function parseHostAllowlist(value = process.env.PUBLIC_NODE_HOST_ALLOWLIST || '') {
+    return value
+        .split(',')
+        .map(entry => normalizeHost(entry))
+        .filter(Boolean);
+}
+
+function isHostAllowedByAllowlist(host, allowlist = []) {
+    if (!allowlist.length) return true;
+
+    const normalized = normalizeHost(host);
+    return allowlist.some((entry) => {
+        if (entry.startsWith('*.')) {
+            const suffix = entry.slice(1);
+            return normalized.endsWith(suffix) && normalized !== suffix.slice(1);
+        }
+        return normalized === entry;
+    });
+}
+
+function ipv4ToInt(address) {
+    const parts = address.split('.').map(Number);
+    if (parts.length !== 4 || parts.some(part => !Number.isInteger(part) || part < 0 || part > 255)) {
+        return null;
+    }
+    return parts.reduce((acc, part) => ((acc << 8) + part) >>> 0, 0);
+}
+
+function ipv4InRange(address, base, bits) {
+    const addressInt = ipv4ToInt(address);
+    const baseInt = ipv4ToInt(base);
+    if (addressInt === null || baseInt === null) return false;
+
+    const mask = bits === 0 ? 0 : (0xFFFFFFFF << (32 - bits)) >>> 0;
+    return (addressInt & mask) === (baseInt & mask);
+}
+
+function isBlockedIPv4(address) {
+    return [
+        ['0.0.0.0', 8],
+        ['10.0.0.0', 8],
+        ['100.64.0.0', 10],
+        ['127.0.0.0', 8],
+        ['169.254.0.0', 16],
+        ['172.16.0.0', 12],
+        ['192.0.0.0', 24],
+        ['192.0.2.0', 24],
+        ['192.168.0.0', 16],
+        ['198.18.0.0', 15],
+        ['198.51.100.0', 24],
+        ['203.0.113.0', 24],
+        ['224.0.0.0', 4],
+        ['240.0.0.0', 4],
+    ].some(([base, bits]) => ipv4InRange(address, base, bits));
+}
+
+function isBlockedIPv6(address) {
+    const normalized = address.toLowerCase();
+
+    if (normalized === '::' || normalized === '::1') return true;
+    if (normalized.startsWith('::ffff:')) {
+        return isBlockedIp(normalized.slice('::ffff:'.length));
+    }
+
+    const firstSegment = normalized.split(':')[0];
+    if (!firstSegment) return false;
+
+    const first = parseInt(firstSegment, 16);
+    if (!Number.isFinite(first)) return false;
+
+    return (
+        (first & 0xFE00) === 0xFC00 || // unique local fc00::/7
+        (first & 0xFFC0) === 0xFE80 || // link-local fe80::/10
+        (first & 0xFF00) === 0xFF00    // multicast ff00::/8
+    );
+}
+
+function isBlockedIp(address) {
+    const version = net.isIP(address);
+    if (version === 4) return isBlockedIPv4(address);
+    if (version === 6) return isBlockedIPv6(address);
+    return true;
+}
+
+function isBlockedHostname(host) {
+    const normalized = normalizeHost(host);
+    return (
+        normalized === 'localhost' ||
+        !normalized.includes('.') ||
+        BLOCKED_HOST_SUFFIXES.some(suffix => normalized.endsWith(suffix))
+    );
+}
+
+function isValidHostname(host) {
+    const normalized = normalizeHost(host);
+    if (!normalized || normalized.length > 253) return false;
+    if (/[\s/@\\]/.test(normalized)) return false;
+    if (net.isIP(normalized)) return true;
+
+    return normalized.split('.').every(label =>
+        label.length > 0 &&
+        label.length <= 63 &&
+        /^[a-z0-9-]+$/.test(label) &&
+        !label.startsWith('-') &&
+        !label.endsWith('-')
+    );
+}
+
+async function resolveHostAddresses(host) {
+    let timeout;
+    try {
+        return await Promise.race([
+            dns.lookup(host, { all: true, verbatim: true }),
+            new Promise((_, reject) => {
+                timeout = setTimeout(() => reject(new Error('DNS lookup timed out')), DNS_LOOKUP_TIMEOUT_MS);
+            }),
+        ]);
+    } finally {
+        clearTimeout(timeout);
+    }
+}
+
+async function isSafeExternalHost(host, { allowlist = [] } = {}) {
+    const normalized = normalizeHost(host);
+
+    if (!isHostAllowedByAllowlist(normalized, allowlist)) return false;
+    if (!isValidHostname(normalized)) return false;
+
+    const ipVersion = net.isIP(normalized);
+    if (ipVersion) return !isBlockedIp(normalized);
+    if (isBlockedHostname(normalized)) return false;
+
+    const addresses = await resolveHostAddresses(normalized);
+    if (!addresses.length) return false;
+
+    return addresses.every(entry => !isBlockedIp(entry.address));
+}
+
+module.exports = {
+    normalizeHost,
+    parseHostAllowlist,
+    isHostAllowedByAllowlist,
+    isBlockedIp,
+    isValidHostname,
+    isSafeExternalHost,
+};

--- a/src/utils/playerLifecycle.js
+++ b/src/utils/playerLifecycle.js
@@ -1,0 +1,70 @@
+const logger = require('./logger');
+
+const queueEndTimeouts = new Map();
+const pendingPlayerUpdates = new Map();
+
+function clearMappedTimeout(map, guildId) {
+    const timeout = map.get(guildId);
+    if (!timeout) return;
+
+    clearTimeout(timeout);
+    map.delete(guildId);
+}
+
+function clearQueueEndTimeout(guildId) {
+    clearMappedTimeout(queueEndTimeouts, guildId);
+}
+
+function setQueueEndTimeout(guildId, timeout) {
+    clearQueueEndTimeout(guildId);
+    queueEndTimeouts.set(guildId, timeout);
+}
+
+function clearAllQueueEndTimeouts() {
+    for (const timeout of queueEndTimeouts.values()) {
+        clearTimeout(timeout);
+    }
+    queueEndTimeouts.clear();
+}
+
+function clearPlayerUpdate(guildId) {
+    clearMappedTimeout(pendingPlayerUpdates, guildId);
+}
+
+function clearAllPlayerUpdates() {
+    for (const timeout of pendingPlayerUpdates.values()) {
+        clearTimeout(timeout);
+    }
+    pendingPlayerUpdates.clear();
+}
+
+function clearGuildLifecycleTimers(guildId) {
+    clearQueueEndTimeout(guildId);
+    clearPlayerUpdate(guildId);
+}
+
+function schedulePlayerUpdate(client, guildId, delay = 500) {
+    if (!client?.playerController || !guildId) return;
+
+    clearPlayerUpdate(guildId);
+
+    const timeout = setTimeout(() => {
+        pendingPlayerUpdates.delete(guildId);
+        client.playerController.updatePlayer(guildId).catch((error) => {
+            logger.debug('Scheduled player update failed:', error?.message || error);
+        });
+    }, delay);
+
+    pendingPlayerUpdates.set(guildId, timeout);
+}
+
+module.exports = {
+    queueEndTimeouts,
+    clearQueueEndTimeout,
+    setQueueEndTimeout,
+    clearAllQueueEndTimeouts,
+    clearPlayerUpdate,
+    clearAllPlayerUpdates,
+    clearGuildLifecycleTimers,
+    schedulePlayerUpdate,
+};

--- a/src/utils/queryGuard.js
+++ b/src/utils/queryGuard.js
@@ -1,0 +1,88 @@
+const { isSafeExternalHost } = require('./networkGuard');
+
+const SEARCH_PREFIXES = [
+    'ytsearch:',
+    'ytmsearch:',
+    'scsearch:',
+    'spsearch:',
+    'amsearch:',
+    'dzsearch:',
+    'ymsearch:',
+];
+
+const BLOCKED_PROTOCOLS = new Set([
+    'data:',
+    'file:',
+    'ftp:',
+    'gopher:',
+    'javascript:',
+]);
+
+function stripToken(token) {
+    return token.replace(/^[<("'`]+|[>)"',`]+$/g, '');
+}
+
+function hasSearchPrefix(value) {
+    const lower = value.toLowerCase();
+    return SEARCH_PREFIXES.some(prefix => lower.startsWith(prefix));
+}
+
+function parseUrlToken(token) {
+    const cleaned = stripToken(token);
+    if (!cleaned || hasSearchPrefix(cleaned)) return null;
+
+    if (/^https?:\/\//i.test(cleaned)) {
+        return new URL(cleaned);
+    }
+
+    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(cleaned)) {
+        return new URL(cleaned);
+    }
+
+    if (/^(localhost|(\d{1,3}\.){3}\d{1,3}|\[[0-9a-f:]+\])(:\d+)?(\/|$)/i.test(cleaned)) {
+        return new URL(`https://${cleaned}`);
+    }
+
+    if (/^(www\.|[a-z0-9-]+(\.[a-z0-9-]+)+)(:\d+)?\//i.test(cleaned)) {
+        return new URL(`https://${cleaned}`);
+    }
+
+    return null;
+}
+
+async function validatePlaybackQuery(query) {
+    const trimmed = String(query || '').trim();
+    if (!trimmed || hasSearchPrefix(trimmed)) {
+        return { allowed: true };
+    }
+
+    const tokens = trimmed.match(/\S+/g) || [];
+
+    for (const token of tokens) {
+        let url;
+        try {
+            url = parseUrlToken(token);
+        } catch {
+            return { allowed: false, reason: 'invalid-url' };
+        }
+
+        if (!url) continue;
+
+        if (BLOCKED_PROTOCOLS.has(url.protocol)) {
+            return { allowed: false, reason: 'blocked-protocol' };
+        }
+
+        if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+            continue;
+        }
+
+        const safeHost = await isSafeExternalHost(url.hostname);
+        if (!safeHost) {
+            return { allowed: false, reason: 'blocked-host' };
+        }
+    }
+
+    return { allowed: true };
+}
+
+module.exports = { validatePlaybackQuery };

--- a/src/utils/queryGuard.js
+++ b/src/utils/queryGuard.js
@@ -18,6 +18,8 @@ const BLOCKED_PROTOCOLS = new Set([
     'javascript:',
 ]);
 
+const QUERY_VALIDATION_TIMEOUT_MS = 2500;
+
 function stripToken(token) {
     return token.replace(/^[<("'`]+|[>)"',`]+$/g, '');
 }
@@ -35,7 +37,7 @@ function parseUrlToken(token) {
         return new URL(cleaned);
     }
 
-    if (/^[a-z][a-z0-9+.-]*:\/\//i.test(cleaned)) {
+    if (/^[a-z][a-z0-9+.-]*:/i.test(cleaned)) {
         return new URL(cleaned);
     }
 
@@ -50,7 +52,7 @@ function parseUrlToken(token) {
     return null;
 }
 
-async function validatePlaybackQuery(query) {
+async function validatePlaybackQueryInner(query) {
     const trimmed = String(query || '').trim();
     if (!trimmed || hasSearchPrefix(trimmed)) {
         return { allowed: true };
@@ -76,13 +78,38 @@ async function validatePlaybackQuery(query) {
             continue;
         }
 
-        const safeHost = await isSafeExternalHost(url.hostname);
+        let safeHost = false;
+        try {
+            safeHost = await isSafeExternalHost(url.hostname);
+        } catch {
+            return { allowed: false, reason: 'blocked-host' };
+        }
         if (!safeHost) {
             return { allowed: false, reason: 'blocked-host' };
         }
     }
 
     return { allowed: true };
+}
+
+// Caps total validation latency so callers can run this before the Discord
+// interaction ACK (3s budget). Timeout fails closed to match the security
+// guarantees documented in the PR.
+async function validatePlaybackQuery(query) {
+    let timeoutId;
+    try {
+        return await Promise.race([
+            validatePlaybackQueryInner(query),
+            new Promise(resolve => {
+                timeoutId = setTimeout(
+                    () => resolve({ allowed: false, reason: 'timeout' }),
+                    QUERY_VALIDATION_TIMEOUT_MS,
+                );
+            }),
+        ]);
+    } finally {
+        clearTimeout(timeoutId);
+    }
 }
 
 module.exports = { validatePlaybackQuery };

--- a/src/utils/trackText.js
+++ b/src/utils/trackText.js
@@ -1,5 +1,5 @@
 const TITLE_NOISE = /\s*[\(\[](official\s*(video|audio|music\s*video|lyric\s*video|visualizer)|lyric\s*video|lyrics?|audio|video|mv|hd|hq|4k|remaster(ed)?|live|ft\.?.*|feat\.?.*|prod\.?.*|visualizer)[\)\]]\s*/gi;
-const ARTIST_NOISE = /\s*(official\s*(youtube\s*)?channel|official|music|vevo|records?|entertainment)\s*/gi;
+const ARTIST_NOISE = /\s*\b(official(?:\s*youtube)?\s*channel|official|vevo|records?|entertainment)\b\s*/gi;
 const TOPIC_SUFFIX = /\s*-\s*Topic$/i;
 
 function normalizeString(str = '') {

--- a/src/utils/trackText.js
+++ b/src/utils/trackText.js
@@ -1,0 +1,52 @@
+const TITLE_NOISE = /\s*[\(\[](official\s*(video|audio|music\s*video|lyric\s*video|visualizer)|lyric\s*video|lyrics?|audio|video|mv|hd|hq|4k|remaster(ed)?|live|ft\.?.*|feat\.?.*|prod\.?.*|visualizer)[\)\]]\s*/gi;
+const ARTIST_NOISE = /\s*(official\s*(youtube\s*)?channel|official|music|vevo|records?|entertainment)\s*/gi;
+const TOPIC_SUFFIX = /\s*-\s*Topic$/i;
+
+function normalizeString(str = '') {
+    return str
+        .toLowerCase()
+        .replace(/\(official\s*(music\s*)?video\)/gi, '')
+        .replace(/\((lyrics?|audio|official\s*audio|visualizer|hd|hq)\)/gi, '')
+        .replace(/\[.*?\]/g, '')
+        .replace(/\s*-\s*topic$/gi, '')
+        .replace(/vevo$/gi, '')
+        .replace(/[^\w\s]/g, '')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function cleanAuthor(author = '') {
+    return author
+        .replace(/vevo$/i, '')
+        .replace(/\s*-\s*topic$/i, '')
+        .replace(/official$/i, '')
+        .trim();
+}
+
+function cleanTitle(title = '') {
+    return title.replace(TITLE_NOISE, '').trim();
+}
+
+function cleanArtist(artist = '') {
+    return artist
+        .replace(TOPIC_SUFFIX, '')
+        .replace(ARTIST_NOISE, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+}
+
+function splitArtistFromTitle(title, artist) {
+    const dashMatch = title.match(/^(.+?)\s*[-\u2013\u2014]\s+(.+)$/);
+    if (dashMatch) {
+        return { title: dashMatch[2], artist: dashMatch[1] };
+    }
+    return { title, artist };
+}
+
+module.exports = {
+    normalizeString,
+    cleanAuthor,
+    cleanTitle,
+    cleanArtist,
+    splitArtistFromTitle,
+};


### PR DESCRIPTION
## What does this PR do?

Hardens correctness, security, and operational reliability across the bot, container, and CI pipeline.

**Correctness & lifecycle**
- Extracts `queueEndTimeouts` and player-update timers into a dedicated `src/utils/playerLifecycle.js` (avoids circular import with `src/index.js`)
- Clears lifecycle timers on voice disconnect, guild delete, `/stop`, player:stop button, search cancel, and shutdown
- Bounds graceful shutdown at 5s using `Promise.race` + `Promise.allSettled` over players and nodes
- Guards `error?.message` and `reason?.reason` in `LavalinkConnectionManager` to prevent `.includes()` crashes on malformed payloads
- Clears `isReconnecting` in `finally` when no retry is scheduled
- Adds an 8s shared `AbortController` timeout across both `/lyrics` fetch paths
- Coalesces per-guild player UI updates via `schedulePlayerUpdate`
- Bounds track title, description, field, and footer to Discord embed limits in `PlayerController`; guards malformed `track.info.uri`

**Security**
- `application.yml`: `sources.http: false` (closes Lavalink SSRF), `retryLimit: 5` (no more busy-loop on YouTube ban), removes no-op `youtubeSearchEnabled`
- New `src/utils/queryGuard.js` + `src/utils/networkGuard.js` validate `/play` and `/search` input: reject loopback, private, link-local, CGNAT, IPv6 ULA/link-local, multicast, and internal-suffix hosts; DNS-checked and fails closed; legitimate search prefixes (`ytsearch:`, `ytmsearch:`, `scsearch:`, `spsearch:`, `amsearch:`, `dzsearch:`, `ymsearch:`) remain allowed
- `PublicNodeProvider`: 256 KB streaming body cap, schema validation, bounded host/password length, secure-first node preference, DNS validation through `networkGuard`, optional `PUBLIC_NODE_HOST_ALLOWLIST` with wildcard support
- Adds `QUERY_NOT_ALLOWED` locale key in `en`, `es`, `it`, `pt-BR`, `tr`

**Docker & Compose**
- Dockerfile: `node:22-alpine` (no patch pin), drops `--ignore-engines`, Node-based heartbeat `HEALTHCHECK`
- Bot writes a heartbeat to `HEALTHCHECK_HEARTBEAT_PATH` every 30s
- `docker-compose.yml`: `restart: unless-stopped` on both services, `mem_limit` + `pids_limit` + `cpus`, json-file log rotation, read-only `application.yml` mount, exec-array bot healthcheck, explicit `/bin/bash` healthcheck for Lavalink (no `/bin/sh /dev/tcp`)
- `.dockerignore`: `*.md` / `*.MD` with `!README.md`

**CI & supply chain**
- Replaces fragile `node --check src/**/*.js` with portable `find src -name '*.js' -exec node --check {} +`
- Adds `npm audit --omit=dev --audit-level=high`
- Pins `aquasecurity/trivy-action` off `@master` to `@v0.35.0`
- Requests provenance `mode=max` and `sbom: true` from `docker/build-push-action`

**Cleanup**
- Consolidates `cleanTitle`, `cleanArtist`, `splitArtistFromTitle`, `normalizeString`, `cleanAuthor` into `src/utils/trackText.js`; `autoplay.js` and `lyrics.js` import from it

## How to test

1. Spin up the stack with `docker compose up --build`; confirm both services come up, healthchecks pass, and logs rotate as expected.
2. Run `/play` and `/search` against malicious/private inputs (e.g. `http://127.0.0.1`, `http://10.0.0.1`, internal hostnames) and confirm they're rejected with the `QUERY_NOT_ALLOWED` message; verify legitimate prefixes (`ytsearch:`, `scsearch:`, etc.) still work.
3. Trigger `/stop`, the player:stop button, a voice disconnect, and a guild delete; confirm queue-end timeouts and update timers are cleared and no orphan players remain.
4. Send `SIGTERM` to the bot and confirm graceful shutdown completes within ~5s even if a node is unresponsive.
5. Run `/lyrics` against a slow/unreachable provider and confirm the 8s timeout aborts cleanly without unhandled rejections.
6. Run the CI workflow on a branch and confirm the syntax check, `npm audit`, Trivy scan, and SBOM/provenance artifacts all succeed.

## Checklist

- [ ] Tested manually with a running bot instance
- [ ] Follows existing code patterns and conventions
- [ ] Commit messages follow [[Conventional Commits](https://www.conventionalcommits.org/)](https://www.conventionalcommits.org)
- [ ] Updated relevant documentation (README, CHANGELOG, etc.) if applicable

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Playback query validation to block unsafe URLs and optional PUBLIC_NODE_HOST_ALLOWLIST for public nodes
  * Centralized player lifecycle scheduling and healthcheck heartbeat for improved reliability

* **Bug Fixes**
  * CI/security workflow pinning and syntax-check improvements
  * Improved Docker build metadata and container healthchecks

* **Configuration**
  * Lavalink and compose config updates; resource limits and centralized logging

* **Localization**
  * Added "query not allowed" message in supported languages

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/lazaroagomez/BeatDock/pull/136)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->