### PR TITLE
docs: add Discord invite link to README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A Discord music bot powered by Lavalink. Simple to deploy, easy to use.
 
+[![Add to Discord](https://img.shields.io/badge/Add%20to%20Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white)](https://discord.com/oauth2/authorize?client_id=1388436020521074759&permissions=3237888&scope=bot%20applications.commands)
+
 [![License](https://img.shields.io/github/license/lazaroagomez/BeatDock)](LICENSE)
 [![Version](https://img.shields.io/github/v/release/lazaroagomez/BeatDock?label=version)](https://github.com/lazaroagomez/BeatDock/releases)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org/)

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
         <a href="https://github.com/lazaroagomez/BeatDock" target="_blank" rel="noopener">GitHub</a>
       </div>
       <div class="navbar__actions">
-        <span class="btn btn--disabled btn--sm" title="Coming soon">Add to Discord <span class="btn__badge">Soon</span></span>
+        <a href="https://discord.com/oauth2/authorize?client_id=1388436020521074759&permissions=3237888&scope=bot%20applications.commands" class="btn btn--primary btn--sm" target="_blank" rel="noopener">Add to Discord</a>
         <button class="navbar__hamburger" id="hamburger" aria-label="Toggle menu">
           <span></span>
           <span></span>
@@ -50,10 +50,10 @@
       <h1 class="hero__title">Your server's soundtrack, handled.</h1>
       <p class="hero__subtitle">A Discord music bot powered by Lavalink. Simple to deploy, easy to use.</p>
       <div class="hero__actions">
-        <span class="btn btn--disabled btn--lg" title="Coming soon">
+        <a href="https://discord.com/oauth2/authorize?client_id=1388436020521074759&permissions=3237888&scope=bot%20applications.commands" class="btn btn--primary btn--lg" target="_blank" rel="noopener">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v8"/><path d="M8 12h8"/></svg>
-          Add to Discord <span class="btn__badge">Soon</span>
-        </span>
+          Add to Discord
+        </a>
         <a href="https://github.com/lazaroagomez/BeatDock" class="btn btn--secondary btn--lg" target="_blank" rel="noopener">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
           View on GitHub


### PR DESCRIPTION
Adds the public invite link for the bot (application ID `1388436020521074759`).

- **README.md** — "Add to Discord" badge under the tagline.
- **docs/index.html** — activates the two previously-disabled "Add to Discord" placeholders (navbar + hero) as live primary buttons.

Permission bitfield (`3237888`) matches the value generated by `src/utils/inviteUrl.js`, so the static links stay in sync with the bot's `/invite` command.

Note: the application **public key** was intentionally not included — it's only used for verifying HTTP interaction-endpoint signatures and has no place in an invite URL or public docs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * "Add to Discord" functionality is now live and enabled, allowing users to add the bot to their Discord server through convenient access points in the navigation bar and hero section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->