### PR TITLE
Autoplay: native YouTube radio engine + repeat fix (2.9.0)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,8 @@ DEFAULT_VOLUME=80
 # Optional: Autoplay Settings
 # Set to true to enable autoplay by default when music starts playing (default: false)
 #AUTOPLAY_DEFAULT=false
+# How many related tracks autoplay queues each time the queue empties (default: 25)
+#AUTOPLAY_TARGET_COUNT=25
 
 # Optional: Default Search Platform Settings
 # Default search platform for user queries (default: ytmsearch)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ All notable changes to BeatDock are documented in this file.
 
 Format based on [Keep a Changelog](https://keepachangelog.com/). This project uses [Semantic Versioning](https://semver.org/).
 
+## [2.9.0] - 2026-06-07
+
+### Changed
+- Autoplay recommendations now rely solely on YouTube's native radio (RD mix), seeded from
+  recent tracks, replacing the previous custom `ytmsearch:` text-search heuristic
+- Autoplay now queues up to 25 related tracks per refill (configurable via `AUTOPLAY_TARGET_COUNT`)
+
+### Fixed
+- Autoplay no longer repeats the same song: hardened deduplication (within-batch checking,
+  wider history window, and version-variant title matching such as `(Live)` vs `(Official Video)`)
+- Removed the random no-dedup fallback that could re-add recently played tracks
+
+### Added
+- `AUTOPLAY_TARGET_COUNT` environment variable to control how many tracks autoplay queues
+- Light non-music filter to skip reactions, trailers, interviews and live streams in autoplay
+
 ## [2.7.4] - 2026-03-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,7 @@ Format based on [Keep a Changelog](https://keepachangelog.com/). This project us
 ### Changed
 - Rewrote README for clarity
 
+[2.9.0]: https://github.com/lazaroagomez/BeatDock/compare/v2.8.0...v2.9.0
 [2.7.4]: https://github.com/lazaroagomez/BeatDock/compare/v2.7.3...v2.7.4
 [2.7.3]: https://github.com/lazaroagomez/BeatDock/compare/v2.7.1...v2.7.3
 [2.7.1]: https://github.com/lazaroagomez/BeatDock/compare/v2.7.0...v2.7.1

--- a/docs/index.html
+++ b/docs/index.html
@@ -33,7 +33,7 @@
         <a href="https://github.com/lazaroagomez/BeatDock" target="_blank" rel="noopener">GitHub</a>
       </div>
       <div class="navbar__actions">
-        <a href="https://discord.com/oauth2/authorize?client_id=1388436020521074759&permissions=3237888&scope=bot%20applications.commands" class="btn btn--primary btn--sm" target="_blank" rel="noopener">Add to Discord</a>
+        <!-- Public bot instance disabled -->
         <button class="navbar__hamburger" id="hamburger" aria-label="Toggle menu">
           <span></span>
           <span></span>
@@ -50,17 +50,14 @@
       <h1 class="hero__title">Your server's soundtrack, handled.</h1>
       <p class="hero__subtitle">A Discord music bot powered by Lavalink. Simple to deploy, easy to use.</p>
       <div class="hero__actions">
-        <a href="https://discord.com/oauth2/authorize?client_id=1388436020521074759&permissions=3237888&scope=bot%20applications.commands" class="btn btn--primary btn--lg" target="_blank" rel="noopener">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v8"/><path d="M8 12h8"/></svg>
-          Add to Discord
-        </a>
-        <a href="https://github.com/lazaroagomez/BeatDock" class="btn btn--secondary btn--lg" target="_blank" rel="noopener">
+        <!-- Public bot instance disabled -->
+        <a href="https://github.com/lazaroagomez/BeatDock" class="btn btn--primary btn--lg" target="_blank" rel="noopener">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
           View on GitHub
         </a>
       </div>
       <div class="hero__badges">
-        <span class="badge">v2.7.4</span>
+        <span class="badge">v2.9.0</span>
         <span class="badge">Apache-2.0</span>
         <span class="badge">Docker Ready</span>
       </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -312,6 +312,7 @@ EMPTY_CHANNEL_DESTROY_MS=60000</code></pre>
                 <tr><td><code>DEFAULT_LANGUAGE</code></td><td><code>en</code></td><td>Bot language (en, es, tr, it)</td></tr>
                 <tr><td><code>DEFAULT_VOLUME</code></td><td><code>80</code></td><td>Default playback volume (0–100)</td></tr>
                 <tr><td><code>AUTOPLAY_DEFAULT</code></td><td><code>false</code></td><td>Enable autoplay by default</td></tr>
+                <tr><td><code>AUTOPLAY_TARGET_COUNT</code></td><td><code>25</code></td><td>Related tracks queued when autoplay refills</td></tr>
                 <tr><td><code>ALLOWED_ROLES</code></td><td>—</td><td>Comma-separated role IDs to restrict access</td></tr>
                 <tr><td><code>DEFAULT_SEARCH_PLATFORM</code></td><td><code>ytmsearch</code></td><td>Default search platform</td></tr>
                 <tr><td><code>LAVALINK_PASSWORD</code></td><td><code>youshallnotpass</code></td><td>Lavalink server password</td></tr>

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "beatdock",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "A modern and efficient Discord music bot with slash commands, multi-language support, and Docker deployment.",
   "main": "src/index.js",
   "scripts": {
     "start": "node src/index.js",
+    "test": "node scripts/test-autoplay.js",
     "docker:build": "docker build -t beatdock:latest .",
     "docker:up": "docker compose up -d",
     "docker:down": "docker compose down",

--- a/scripts/test-autoplay.js
+++ b/scripts/test-autoplay.js
@@ -3,6 +3,8 @@
 
 const assert = require('node:assert/strict');
 const { normalizeString } = require('../src/utils/trackText');
+// Pin the target before loading autoplay — it reads AUTOPLAY_TARGET_COUNT at require time.
+process.env.AUTOPLAY_TARGET_COUNT = '25';
 const { findAutoplayTracks } = require('../src/utils/autoplay');
 
 let passed = 0;

--- a/scripts/test-autoplay.js
+++ b/scripts/test-autoplay.js
@@ -1,0 +1,136 @@
+// Deterministic test for the autoplay engine. No Lavalink/network required.
+// Run: node scripts/test-autoplay.js  (exits non-zero on any failed assertion)
+
+const assert = require('node:assert/strict');
+const { normalizeString } = require('../src/utils/trackText');
+const { findAutoplayTracks } = require('../src/utils/autoplay');
+
+let passed = 0;
+function check(name, fn) {
+    return fn().then(() => { passed++; console.log(`  ok  - ${name}`); })
+        .catch((err) => { console.error(`FAIL - ${name}\n      ${err.message}`); process.exitCode = 1; });
+}
+
+function track(id, title, opts = {}) {
+    return {
+        info: {
+            identifier: id,
+            title,
+            author: opts.author || 'Artist',
+            sourceName: opts.sourceName || 'youtube',
+            isrc: opts.isrc || null,
+            isStream: opts.isStream || false,
+        },
+    };
+}
+
+// Fake player whose search() returns canned RD mixes keyed by the seed video id.
+function makePlayer({ previous = [], mixes = {} }) {
+    return {
+        queue: { current: null, previous, tracks: [] },
+        async search({ query }) {
+            const m = query.match(/list=RD([^&]+)/);
+            const id = m ? m[1] : null;
+            const tracks = (mixes[id] || []).map((t) => track(t.id, t.title, t));
+            return { loadType: 'playlist', tracks };
+        },
+    };
+}
+
+function ids(list) { return list.map((t) => t.info.identifier); }
+function hasUnique(arr) { return new Set(arr).size === arr.length; }
+
+async function main() {
+    // ── Scenario 1: dedup + multi-seed accumulation + non-music + ISRC ──
+    await check('dedups ids/titles/isrc, excludes seed+recent, accumulates across seeds, drops non-music', async () => {
+        const seed = track('s1', 'Seed Song');
+        const recent = track('h1', 'Old Song');
+        const player = makePlayer({
+            previous: [recent],
+            mixes: {
+                s1: [
+                    { id: 's1', title: 'Seed Song' },                 // the seed itself -> excluded
+                    { id: 'h1', title: 'Old Song' },                  // recent history -> excluded
+                    { id: 'a1', title: 'Alpha' },
+                    { id: 'a2', title: 'Alpha' },                     // same title -> dedup
+                    { id: 'b1', title: 'Beta (Live)' },
+                    { id: 'b2', title: 'Beta (Official Video)' },     // same recording -> dedup
+                    { id: 'g1', title: 'Eta', isrc: 'ISRC0001' },
+                    { id: 'g2', title: 'Totally Different Name', isrc: 'ISRC0001' }, // same ISRC -> dedup
+                    { id: 'r1', title: 'Alpha Song Reaction!' },      // non-music -> excluded from collected
+                    { id: 'c1', title: 'Gamma' },
+                    { id: 'd1', title: 'Delta' },
+                ],
+                h1: [
+                    { id: 'a1', title: 'Alpha' },                     // cross-seed dup -> excluded
+                    { id: 'c1', title: 'Gamma' },                     // cross-seed dup -> excluded
+                    { id: 'e1', title: 'Epsilon' },                  // new, only reachable via 2nd seed
+                    { id: 'f1', title: 'Zeta' },                     // new
+                ],
+            },
+        });
+
+        const out = await findAutoplayTracks(player, seed);
+        const outIds = ids(out);
+
+        assert.ok(!outIds.includes('s1') && !outIds.includes('h1'), 'must exclude seed and recent history');
+        assert.ok(hasUnique(outIds), `ids must be unique, got ${outIds}`);
+        assert.ok(hasUnique(out.map((t) => normalizeString(t.info.title))), 'normalized titles must be unique');
+        const isrcs = out.map((t) => t.info.isrc).filter(Boolean);
+        assert.ok(hasUnique(isrcs), 'isrcs must be unique');
+        assert.ok(!outIds.includes('r1'), 'non-music reaction must be excluded');
+        // Reachable only from the 2nd seed -> proves accumulation across seeds.
+        assert.ok(outIds.includes('e1') && outIds.includes('f1'), 'must accumulate from second seed');
+        // Expected unique songs: Alpha, Beta, Eta, Gamma, Delta, Epsilon, Zeta = 7
+        assert.equal(out.length, 7, `expected 7 unique tracks, got ${out.length} (${outIds})`);
+    });
+
+    // ── Scenario 2: caps at AUTOPLAY_TARGET (25) ──
+    await check('caps the batch at 25', async () => {
+        const big = Array.from({ length: 40 }, (_, i) => ({ id: `t${i}`, title: `Song ${i}` }));
+        const player = makePlayer({ previous: [], mixes: { seedBig: big } });
+        const out = await findAutoplayTracks(player, track('seedBig', 'Seed'));
+        assert.equal(out.length, 25, `expected cap of 25, got ${out.length}`);
+        assert.ok(hasUnique(ids(out)), 'ids unique under cap');
+    });
+
+    // ── Scenario 3: only non-music available -> fall back rather than return silence ──
+    await check('falls back to non-music only when nothing else is available', async () => {
+        const player = makePlayer({
+            previous: [],
+            mixes: { onlyjunk: [{ id: 'x1', title: 'Live Stream', isStream: true }, { id: 'x2', title: 'Gameplay Highlights' }] },
+        });
+        const out = await findAutoplayTracks(player, track('onlyjunk', 'Seed'));
+        assert.ok(out.length >= 1, 'should return a fallback rather than nothing');
+    });
+
+    // ── Scenario 4: non-YouTube seed with no YT history -> empty (no search fallback) ──
+    await check('returns [] for a non-YouTube seed with no usable history', async () => {
+        const player = makePlayer({ previous: [], mixes: {} });
+        const out = await findAutoplayTracks(player, track('sp1', 'Spotify Song', { sourceName: 'spotify' }));
+        assert.equal(out.length, 0, 'no YT seed -> no recommendations');
+    });
+
+    // ── Scenario 5: title normaliser collapses version variants ──
+    await check('normalizeString collapses common version variants', async () => {
+        const base = normalizeString('Blinding Lights');
+        for (const v of [
+            'Blinding Lights (Official Video)',
+            'Blinding Lights (Official Music Video)',
+            'Blinding Lights [Lyric Video]',
+            'Blinding Lights (Live)',
+            'Blinding Lights - Topic',
+            'Blinding Lights (sped up)',
+            'Blinding Lights (feat. Someone)',
+            'Blinding Lights (Remastered 2020)',
+        ]) {
+            assert.equal(normalizeString(v), base, `"${v}" should normalize to "${base}"`);
+        }
+        // Distinct songs must NOT collapse.
+        assert.notEqual(normalizeString('Video Games'), normalizeString('Games'), 'distinct titles must stay distinct');
+    });
+
+    console.log(`\n${passed} check(s) passed${process.exitCode ? ', with failures' : ''}.`);
+}
+
+main();

--- a/src/utils/autoplay.js
+++ b/src/utils/autoplay.js
@@ -102,7 +102,14 @@ async function findAutoplayTracks(player, lastPlayedTrack) {
     const history = player.queue.previous.slice(-HISTORY_WINDOW);
     const seen = getRecentIdentifiers(player);
     seen.add(lastPlayedTrack.info.identifier);
-    const dedupHistory = history.slice();
+    // ISRC/title dedup baseline — include currently playing, queued, and the just-finished
+    // track so same-song variants with a different identifier are still caught.
+    const dedupHistory = [
+        ...(player.queue.current?.info ? [player.queue.current] : []),
+        ...history.filter((t) => t?.info),
+        ...player.queue.tracks.filter((t) => t?.info),
+        lastPlayedTrack,
+    ];
 
     const collected = [];
     const nonMusic = []; // deduped fallback, used only if everything else is filtered out

--- a/src/utils/autoplay.js
+++ b/src/utils/autoplay.js
@@ -1,14 +1,30 @@
-// Autoplay recommendation engine — 3-tier cascade with 3-layer deduplication.
-// Tier 1: YouTube Mix URL (YouTube's recommendation algorithm)
-// Tier 2: Smart search rotation via YouTube Music
-// Tier 3: Relaxed dedup last resort
+// Autoplay recommendation engine — YouTube's native radio (RD mix) with hardened dedup.
+// Seeds YouTube's server-side radio from the last played track (and recent history when
+// one mix is short), accumulates a deduplicated batch of related tracks, and filters out
+// non-music. No external services or credentials.
 
-const { cleanAuthor, normalizeString } = require('./trackText');
+const { normalizeString } = require('./trackText');
+const logger = require('./logger');
+
+const AUTOPLAY_TARGET = Math.max(1, parseInt(process.env.AUTOPLAY_TARGET_COUNT || '25', 10) || 25);
+const MAX_SEEDS = 3;
+const HISTORY_WINDOW = 50;
+
+// Clearly non-music uploads to skip. Kept deliberately small to avoid false positives.
+// NOTE: "live"/"cover" are intentionally NOT here — they are music; the title normaliser
+// already collapses live/alternate re-uploads of an already-played song during dedup.
+const NON_MUSIC = /\b(reaction|trailer|teaser|interview|podcast|review|tutorial|gameplay|highlights?|behind\s+the\s+scenes|full\s+(?:movie|album|concert))\b/i;
+const TOPIC_AUTHOR = /-\s*topic\s*$/i;
+
+function isYouTubeSource(track) {
+    const source = track?.info?.sourceName;
+    return source === 'youtube' || source === 'youtubemusic';
+}
 
 function getRecentIdentifiers(player) {
     const ids = new Set();
     if (player.queue.current) ids.add(player.queue.current.info.identifier);
-    for (const t of player.queue.previous.slice(-25)) {
+    for (const t of player.queue.previous.slice(-HISTORY_WINDOW)) {
         ids.add(t.info.identifier);
     }
     for (const t of player.queue.tracks) {
@@ -17,19 +33,19 @@ function getRecentIdentifiers(player) {
     return ids;
 }
 
+// 3-layer match: exact id, ISRC (same recording across uploads), normalised title
+// (covers re-uploads / official-video vs audio / lyric videos).
 function isDuplicate(track, recentIds, history) {
-    // Layer 1: Exact identifier match (O(1))
     if (recentIds.has(track.info.identifier)) return true;
 
-    // Layer 2: ISRC match (same recording across uploads)
     if (track.info.isrc) {
         for (const h of history) {
             if (h.info.isrc && h.info.isrc === track.info.isrc) return true;
         }
     }
 
-    // Layer 3: Normalized title match (catches covers, re-uploads, lyric videos)
     const normalized = normalizeString(track.info.title);
+    if (!normalized) return false;
     for (const h of history) {
         const hNorm = normalizeString(h.info.title);
         if (normalized === hNorm) return true;
@@ -37,120 +53,84 @@ function isDuplicate(track, recentIds, history) {
             if (normalized.includes(hNorm) || hNorm.includes(normalized)) return true;
         }
     }
-
     return false;
 }
 
-function filterCandidates(tracks, recentIds, history) {
-    return tracks.filter(t => !isDuplicate(t, recentIds, history));
+function looksLikeNonMusic(track) {
+    if (track.info.isStream) return true;
+    return NON_MUSIC.test(track.info.title || '');
 }
 
-function pickRandom(arr, max = 3) {
-    const index = Math.floor(Math.random() * Math.min(max, arr.length));
-    return arr[index];
+// Songs/audio (Art Tracks, YT Music, ISRC-bearing) are preferred over plain videos so
+// that, when duplicates collapse or the batch overflows, the music-video copy is dropped.
+function isSongLike(track) {
+    const info = track.info;
+    return Boolean(info.isrc) || info.sourceName === 'youtubemusic' || TOPIC_AUTHOR.test(info.author || '');
+}
+
+function buildSeeds(lastPlayedTrack, history) {
+    const seedIds = new Set();
+    const seeds = [];
+    for (const t of [lastPlayedTrack, ...history.slice().reverse()]) {
+        const id = t?.info?.identifier;
+        if (!id || !isYouTubeSource(t) || seedIds.has(id)) continue;
+        seedIds.add(id);
+        seeds.push(t);
+        if (seeds.length >= MAX_SEEDS) break;
+    }
+    return seeds;
+}
+
+async function fetchMix(player, videoId) {
+    try {
+        const mixUrl = `https://www.youtube.com/watch?v=${videoId}&list=RD${videoId}`;
+        const res = await player.search({ query: mixUrl });
+        return res?.tracks || [];
+    } catch {
+        return [];
+    }
 }
 
 /**
- * Finds autoplay tracks using a 3-tier cascade strategy.
- * Returns an array of 0-2 tracks to add to the queue.
+ * Builds an autoplay batch from YouTube's native radio (RD mix), seeded from the last
+ * played track and recent history. Returns up to AUTOPLAY_TARGET unique, deduplicated
+ * tracks, or [] when no usable recommendations are found.
  */
 async function findAutoplayTracks(player, lastPlayedTrack) {
     if (!lastPlayedTrack?.info) return [];
 
-    const recentIds = getRecentIdentifiers(player);
-    recentIds.add(lastPlayedTrack.info.identifier);
-    const history = player.queue.previous.slice(-25);
-    const videoId = lastPlayedTrack.info.identifier;
-    const source = lastPlayedTrack.info.sourceName;
-    const author = lastPlayedTrack.info.author;
-    const title = lastPlayedTrack.info.title;
+    const history = player.queue.previous.slice(-HISTORY_WINDOW);
+    const seen = getRecentIdentifiers(player);
+    seen.add(lastPlayedTrack.info.identifier);
+    const dedupHistory = history.slice();
 
-    // ── TIER 1: YouTube Mix URL (best recommendations) ──
-    if (source === 'youtube' || source === 'youtubemusic') {
-        try {
-            const mixUrl = `https://www.youtube.com/watch?v=${videoId}&list=RD${videoId}`;
-            const res = await player.search({ query: mixUrl });
+    const collected = [];
+    const nonMusic = []; // deduped fallback, used only if everything else is filtered out
+    const seeds = buildSeeds(lastPlayedTrack, history);
 
-            if (res?.tracks?.length) {
-                const candidates = filterCandidates(res.tracks, recentIds, history);
-                if (candidates.length > 0) return candidates.slice(0, 2);
-            }
-        } catch {
-            // Mix URL failed — fall through to Tier 2
+    for (const seed of seeds) {
+        if (collected.length >= AUTOPLAY_TARGET) break;
+
+        const tracks = await fetchMix(player, seed.info.identifier);
+        if (!tracks.length) continue;
+
+        const ordered = [...tracks].sort((a, b) => Number(isSongLike(b)) - Number(isSongLike(a)));
+
+        for (const track of ordered) {
+            if (collected.length >= AUTOPLAY_TARGET) break;
+            if (!track?.info || isDuplicate(track, seen, dedupHistory)) continue;
+
+            seen.add(track.info.identifier);
+            dedupHistory.push(track);
+
+            if (looksLikeNonMusic(track)) nonMusic.push(track);
+            else collected.push(track);
         }
     }
 
-    // ── TIER 2: Smart search rotation via YouTube Music ──
-    if (author) {
-        const artist = cleanAuthor(author);
-        const cleanedTitle = title.replace(/\(.*?\)/g, '').replace(/\[.*?\]/g, '').trim();
-        const partialTitle = cleanedTitle.split(' ').slice(0, 3).join(' ');
-
-        const queryStrategies = [
-            `ytmsearch:${artist}`,
-            `ytmsearch:${artist} mix`,
-            `ytmsearch:${artist} ${partialTitle}`,
-        ];
-
-        // Detect same-artist saturation: if 3+ of last 5 tracks share the same artist,
-        // broaden the query to break out of the artist loop
-        const last5Artists = history.slice(-5).map(t => normalizeString(cleanAuthor(t.info.author)));
-        const artistCount = last5Artists.filter(a => a === normalizeString(artist)).length;
-        if (artistCount >= 3) {
-            queryStrategies.unshift(`ytmsearch:${cleanedTitle} music`);
-        }
-
-        // Add variety from recent history — cross-pollinate artists
-        const recentArtists = [...new Set(
-            history.slice(-10).map(t => cleanAuthor(t.info.author))
-        )].filter(a => a !== artist);
-
-        if (recentArtists.length > 0) {
-            const altArtist = pickRandom(recentArtists);
-            queryStrategies.push(`ytmsearch:${altArtist} ${artist}`);
-        }
-
-        // Shuffle strategies but keep the first (most relevant) in position
-        const [primary, ...rest] = queryStrategies;
-        const shuffledRest = rest.sort(() => Math.random() - 0.5);
-        const orderedStrategies = [primary, ...shuffledRest];
-
-        for (const query of orderedStrategies) {
-            try {
-                const res = await player.search({ query });
-
-                if (res?.tracks?.length) {
-                    const candidates = filterCandidates(res.tracks, recentIds, history);
-                    if (candidates.length > 0) return candidates.slice(0, 2);
-                }
-            } catch {
-                continue;
-            }
-        }
-    }
-
-    // ── TIER 3: Last resort — relaxed dedup to prevent silence ──
-    try {
-        const artist = author ? cleanAuthor(author) : '';
-        const query = artist ? `ytmsearch:${artist}` : `ytmsearch:${normalizeString(title)}`;
-        const res = await player.search({ query });
-
-        if (res?.tracks?.length) {
-            // Only check against last 10 tracks (relaxed)
-            const relaxedIds = new Set(
-                player.queue.previous.slice(-10).map(t => t.info.identifier)
-            );
-            const fallback = res.tracks.find(t => !relaxedIds.has(t.info.identifier));
-            if (fallback) return [fallback];
-
-            // Absolute last resort: pick something random
-            return [res.tracks[Math.floor(Math.random() * res.tracks.length)]];
-        }
-    } catch {
-        // All strategies exhausted — queueEnd event will fire
-    }
-
-    return [];
+    const result = (collected.length ? collected : nonMusic).slice(0, AUTOPLAY_TARGET);
+    logger.debug(`Autoplay: ${result.length} track(s) from ${seeds.length} seed(s)`);
+    return result;
 }
 
 module.exports = { findAutoplayTracks };

--- a/src/utils/trackText.js
+++ b/src/utils/trackText.js
@@ -2,17 +2,23 @@ const TITLE_NOISE = /\s*[\(\[](official\s*(video|audio|music\s*video|lyric\s*vid
 const ARTIST_NOISE = /\s*\b(official(?:\s*youtube)?\s*channel|official|vevo|records?|entertainment)\b\s*/gi;
 const TOPIC_SUFFIX = /\s*-\s*Topic$/i;
 
+// Version/edition qualifiers that mark the SAME recording across re-uploads
+// (e.g. "Song (Live)" vs "Song (Official Video)"). Stripped only when trailing
+// and not parenthesised, so real titles ending in these words stay rare-but-safe.
+const TRAILING_QUALIFIER = /[\s\-_]+(official\s*(music\s*)?video|official\s*(music\s*)?audio|official\s*music\s*video|lyric\s*video|lyrics?|visualizer|audio|video|hd|hq|4k|remaster(?:ed)?(?:\s*\d{4})?|live|acoustic|unplugged|sped\s*up|slowed(?:\s*\+?\s*reverb)?|reverb|nightcore|8d(?:\s*audio)?|bass\s*boost(?:ed)?)\s*$/i;
+
 function normalizeString(str = '') {
-    return str
-        .toLowerCase()
-        .replace(/\(official\s*(music\s*)?video\)/gi, '')
-        .replace(/\((lyrics?|audio|official\s*audio|visualizer|hd|hq)\)/gi, '')
-        .replace(/\[.*?\]/g, '')
-        .replace(/\s*-\s*topic$/gi, '')
-        .replace(/vevo$/gi, '')
-        .replace(/[^\w\s]/g, '')
-        .replace(/\s+/g, ' ')
-        .trim();
+    let s = str.toLowerCase();
+    // Drop featuring/production credits and everything trailing them.
+    s = s.replace(/\b(feat|ft|featuring|prod)\b\.?.*$/i, '');
+    // Drop bracketed/parenthesised noise — version tags, credits, etc.
+    s = s.replace(/\[[^\]]*\]/g, '').replace(/\([^)]*\)/g, '');
+    // Drop auto-generated channel suffixes.
+    s = s.replace(/\s*-\s*topic\s*$/i, '').replace(/vevo\s*$/i, '');
+    // Repeatedly strip trailing version/edition qualifiers (handles stacked tags).
+    let prev;
+    do { prev = s; s = s.replace(TRAILING_QUALIFIER, ''); } while (s !== prev);
+    return s.replace(/[^\w\s]/g, '').replace(/\s+/g, ' ').trim();
 }
 
 function cleanAuthor(author = '') {


### PR DESCRIPTION
## Summary

Reworks autoplay to fix duplicate songs and produce a full set of recommendations, by leaning entirely on YouTube's native radio instead of the previous custom `ytmsearch:` text-search heuristic. Also disables the public bot instance on the landing page and bumps the version to **2.9.0**.

## Background

Research confirmed there is **no better YouTube-native recommendation mechanism** available in this stack — LavaSrc exposes no `ytm`/`yt` recommendation prefix, lavalink-client v2.10.1 has no `getRecommendations()`, and youtube-source has no related-tracks API. The `RD{videoId}` mix URL the bot already used **is** the best native radio primitive (it hits YouTube's InnerTube `/next` endpoint server-side). The only "native better" option (Deezer `dzrec:`) requires credentials, which is out of scope — BeatDock stays credential-free.

## What changed

**Autoplay engine (`src/utils/autoplay.js`)**
- Removed the custom `ytmsearch:` query rotation and the random no-dedup fallback.
- Single native tier: seeds YouTube's RD radio from the last track (+ up to 2 recent-history tracks if a mix is short) and accumulates up to **25** deduplicated tracks.
- Hardened dedup that fixes the repeats:
  - within-batch deduplication (candidates checked against each other, not just history)
  - history window widened 25 → 50
  - the title normaliser now collapses version variants, so `"Song (Live)"` and `"Song (Official Video)"` are recognised as the same recording
- Light non-music filter (reactions, trailers, interviews, live streams) and a preference for song/audio uploads over plain videos.

**Title normaliser (`src/utils/trackText.js`)** — `normalizeString` now strips trailing version/edition qualifiers and `feat.`/`prod.` credits (reused by the dedup layer). `cleanTitle`/`cleanArtist` (used by `/lyrics`) are unchanged.

**Config** — new `AUTOPLAY_TARGET_COUNT` env var (default 25), documented in `.env.example`.

**Landing page (`docs/index.html`)** — disabled the public bot instance (removed both "Add to Discord" OAuth buttons; the hero now leads with "View on GitHub"); version badge → v2.9.0.

**Versioning** — `package.json` 2.8.0 → 2.9.0, CHANGELOG entry added.

## Testing

Added a deterministic, network-free test harness (`scripts/test-autoplay.js`, wired to `npm test`) with a fake player/stubbed search. Covers: dedup by id/ISRC/normalized-title, exclusion of seed + recent history, multi-seed accumulation, the 25-track cap, non-music filtering, and the normaliser's version-variant collapsing. All 5 checks pass.

```
npm test
```

## Notes

- Tradeoff: `live`/`cover` are treated as music (not filtered out); the normaliser still dedups live re-uploads of an already-played song.
- With the `ytmsearch:` fallback removed, if YouTube's mix endpoint fails for all seeds, autoplay stops rather than degrading to text search (mitigated by trying up to 3 seeds).
- RD-mix tracks are `youtube`-source with `isrc: null`, so music-video-vs-song detection is heuristic (author `- Topic` / `youtubemusic` source / title signals), not exact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Autoplay now seeds recommendations from YouTube’s native radio and fills the queue up to a configurable batch size (default 25).
  * Added lightweight non-music filtering to skip reactions, trailers, interviews, and live streams.

* **Bug Fixes**
  * Stronger deduplication with broader title normalization and variant matching to avoid repeats.

* **Documentation**
  * Site updated to v2.9.0; setup docs include AUTOPLAY_TARGET_COUNT and release notes. Nav no longer exposes the public "Add to Discord" action.

* **Tests**
  * Added a deterministic autoplay test script validating dedupe, filtering, and target sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->