### PR TITLE
chore(dependabot): hold version updates for 30 days (stability window)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "09:00"
+    # Hold version updates for ~1 month after release so they bake before adoption
+    cooldown:
+      default-days: 30
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
@@ -22,6 +25,9 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "10:00"
+    # Hold version updates for ~1 month after release so they bake before adoption
+    cooldown:
+      default-days: 30
     open-pull-requests-limit: 3
     commit-message:
       prefix: "docker"
@@ -40,6 +46,9 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "11:00"
+    # Hold version updates for ~1 month after release so they bake before adoption
+    cooldown:
+      default-days: 30
     open-pull-requests-limit: 2
     commit-message:
       prefix: "ci"


### PR DESCRIPTION
## Summary

Adds a **30-day `cooldown`** to all three Dependabot ecosystems (npm, Docker, GitHub Actions) so dependency update PRs are only opened for versions that have been **released for at least a month**.

## Why

We want each release to "bake" before adoption — no bleeding-edge updates. With this in place, Dependabot will only surface a version once it has been out for ~30 days, giving the wider community time to hit any regressions first. This keeps the bot stable and means we only act on updates that have proven themselves for at least a month.

This is the native, no-AI way to enforce the "wait at least one month before updating" policy — it uses the Dependabot we already have rather than any external/scheduled tooling.

## What changed

`.github/dependabot.yml` — added to each `updates` entry:

```yaml
    cooldown:
      default-days: 30
```

## Notes

- Per Dependabot docs, `cooldown` applies to **version updates only** — **security updates are not delayed**, so urgent CVE fixes still come through promptly.
- Existing `ignore` rules (e.g. pinning the Docker image to the Node 22 LTS line) are unchanged.
- Recently opened dependabot PRs were closed in favor of this window; they'll reappear once those versions are ≥30 days old (if still the latest).
