### PR TITLE
chore: update GitHub username refs (lazaroagomez -> albertgmz)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,8 @@
-# Set @lazaroagomez as the default owner for everything
-* @lazaroagomez
+# Set @albertgmz as the default owner for everything
+* @albertgmz
 
 # Dependency files
-package*.json @lazaroagomez
-Dockerfile @lazaroagomez
-docker-compose.yml @lazaroagomez
-.github/ @lazaroagomez
+package*.json @albertgmz
+Dockerfile @albertgmz
+docker-compose.yml @albertgmz
+.github/ @albertgmz

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -58,4 +58,4 @@ docs/            GitHub Pages website
 
 ## Need help?
 
-Open an [Issue](https://github.com/lazaroagomez/BeatDock/issues), happy to help.
+Open an [Issue](https://github.com/albertgmz/BeatDock/issues), happy to help.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Question / Help
-    url: https://github.com/lazaroagomez/BeatDock/discussions
+    url: https://github.com/albertgmz/BeatDock/discussions
     about: Ask questions and get help from the community
   - name: Security Vulnerability
-    url: https://github.com/lazaroagomez/BeatDock/security/advisories/new
+    url: https://github.com/albertgmz/BeatDock/security/advisories/new
     about: Report a security vulnerability (do not open a public issue)

--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,14 +4,14 @@ Need help with BeatDock? Here's where to go.
 
 ## Getting help
 
-- **Bug reports** - [open an issue](https://github.com/lazaroagomez/BeatDock/issues/new?template=bug_report.yml)
-- **Feature ideas** - [open a feature request](https://github.com/lazaroagomez/BeatDock/issues/new?template=feature_request.yml)
-- **General questions** - [start a discussion](https://github.com/lazaroagomez/BeatDock/discussions)
+- **Bug reports** - [open an issue](https://github.com/albertgmz/BeatDock/issues/new?template=bug_report.yml)
+- **Feature ideas** - [open a feature request](https://github.com/albertgmz/BeatDock/issues/new?template=feature_request.yml)
+- **General questions** - [start a discussion](https://github.com/albertgmz/BeatDock/discussions)
 
 ## Before opening an issue
 
 1. Check the [README](../README.md), especially the Configuration and Troubleshooting sections.
-2. Search [existing issues](https://github.com/lazaroagomez/BeatDock/issues) to see if it's already been reported.
+2. Search [existing issues](https://github.com/albertgmz/BeatDock/issues) to see if it's already been reported.
 3. Make sure you're on the latest version (`docker compose pull && docker compose up -d`).
 
 ## Security vulnerabilities

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,11 +82,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/). This project us
 ### Changed
 - Rewrote README for clarity
 
-[2.9.0]: https://github.com/lazaroagomez/BeatDock/compare/v2.8.0...v2.9.0
-[2.7.4]: https://github.com/lazaroagomez/BeatDock/compare/v2.7.3...v2.7.4
-[2.7.3]: https://github.com/lazaroagomez/BeatDock/compare/v2.7.1...v2.7.3
-[2.7.1]: https://github.com/lazaroagomez/BeatDock/compare/v2.7.0...v2.7.1
-[2.7.0]: https://github.com/lazaroagomez/BeatDock/compare/v2.6.0...v2.7.0
-[2.6.0]: https://github.com/lazaroagomez/BeatDock/compare/v2.4.2...v2.6.0
-[2.4.2]: https://github.com/lazaroagomez/BeatDock/compare/v2.4.0...v2.4.2
-[2.4.0]: https://github.com/lazaroagomez/BeatDock/releases/tag/v2.4.0
+[2.9.0]: https://github.com/albertgmz/BeatDock/compare/v2.8.0...v2.9.0
+[2.7.4]: https://github.com/albertgmz/BeatDock/compare/v2.7.3...v2.7.4
+[2.7.3]: https://github.com/albertgmz/BeatDock/compare/v2.7.1...v2.7.3
+[2.7.1]: https://github.com/albertgmz/BeatDock/compare/v2.7.0...v2.7.1
+[2.7.0]: https://github.com/albertgmz/BeatDock/compare/v2.6.0...v2.7.0
+[2.6.0]: https://github.com/albertgmz/BeatDock/compare/v2.4.2...v2.6.0
+[2.4.2]: https://github.com/albertgmz/BeatDock/compare/v2.4.0...v2.4.2
+[2.4.0]: https://github.com/albertgmz/BeatDock/releases/tag/v2.4.0

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 A Discord music bot powered by Lavalink. Simple to deploy, easy to use.
 
-[![License](https://img.shields.io/github/license/lazaroagomez/BeatDock)](LICENSE)
-[![Version](https://img.shields.io/github/v/release/lazaroagomez/BeatDock?label=version)](https://github.com/lazaroagomez/BeatDock/releases)
+[![License](https://img.shields.io/github/license/albertgmz/BeatDock)](LICENSE)
+[![Version](https://img.shields.io/github/v/release/albertgmz/BeatDock?label=version)](https://github.com/albertgmz/BeatDock/releases)
 [![Node](https://img.shields.io/badge/node-%3E%3D22-brightgreen)](https://nodejs.org/)
-[![Docker](https://img.shields.io/badge/docker-ready-blue)](https://github.com/lazaroagomez/BeatDock/pkgs/container/beatdock)
-[![Last Commit](https://img.shields.io/github/last-commit/lazaroagomez/BeatDock)](https://github.com/lazaroagomez/BeatDock/commits/main)
-[![Issues](https://img.shields.io/github/issues/lazaroagomez/BeatDock)](https://github.com/lazaroagomez/BeatDock/issues)
-[![CI](https://img.shields.io/github/actions/workflow/status/lazaroagomez/BeatDock/ci.yml?label=CI)](https://github.com/lazaroagomez/BeatDock/actions/workflows/ci.yml)
-[![Security](https://img.shields.io/github/actions/workflow/status/lazaroagomez/BeatDock/security.yml?label=security)](https://github.com/lazaroagomez/BeatDock/actions/workflows/security.yml)
+[![Docker](https://img.shields.io/badge/docker-ready-blue)](https://github.com/albertgmz/BeatDock/pkgs/container/beatdock)
+[![Last Commit](https://img.shields.io/github/last-commit/albertgmz/BeatDock)](https://github.com/albertgmz/BeatDock/commits/main)
+[![Issues](https://img.shields.io/github/issues/albertgmz/BeatDock)](https://github.com/albertgmz/BeatDock/issues)
+[![CI](https://img.shields.io/github/actions/workflow/status/albertgmz/BeatDock/ci.yml?label=CI)](https://github.com/albertgmz/BeatDock/actions/workflows/ci.yml)
+[![Security](https://img.shields.io/github/actions/workflow/status/albertgmz/BeatDock/security.yml?label=security)](https://github.com/albertgmz/BeatDock/actions/workflows/security.yml)
 [![Ko-fi](https://img.shields.io/badge/Ko--fi-support-ff5e5b?logo=ko-fi&logoColor=white)](https://ko-fi.com/lazaroagomez)
 
 ---
@@ -70,7 +70,7 @@ TOKEN=your_discord_bot_token
 services:
   bot:
     container_name: beatdock
-    image: ghcr.io/lazaroagomez/beatdock:latest
+    image: ghcr.io/albertgmz/beatdock:latest
     depends_on:
       lavalink:
         condition: service_healthy
@@ -160,7 +160,7 @@ docker compose up -d
 ### Option B: Deploy from Source
 
 ```bash
-git clone https://github.com/lazaroagomez/BeatDock.git
+git clone https://github.com/albertgmz/BeatDock.git
 cd BeatDock
 ```
 
@@ -247,7 +247,7 @@ Raspberry Pi 5 (Debian 13) may use a 16KB memory page size, which is incompatibl
 getconf PAGE_SIZE
 ```
 
-If the result is not `4096`, add `kernel=kernel8.img` under the `[all]` section in `/boot/firmware/config.txt`, then reboot and restart the containers. See [#109](https://github.com/lazaroagomez/BeatDock/issues/109) for details.
+If the result is not `4096`, add `kernel=kernel8.img` under the `[all]` section in `/boot/firmware/config.txt`, then reboot and restart the containers. See [#109](https://github.com/albertgmz/BeatDock/issues/109) for details.
 
 ## Built With
 
@@ -265,8 +265,8 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for setup instructions and guidel
 
 ## Links
 
-- [Website](https://lazaroagomez.github.io/BeatDock)
-- [Issues](https://github.com/lazaroagomez/BeatDock/issues)
+- [Website](https://albertgmz.github.io/BeatDock)
+- [Issues](https://github.com/albertgmz/BeatDock/issues)
 - [Changelog](CHANGELOG.md)
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ x-logging: &default-logging
 services:
   bot:
     container_name: beatdock
-    image: ghcr.io/lazaroagomez/beatdock:latest
+    image: ghcr.io/albertgmz/beatdock:latest
     build:
       context: .
       dockerfile: Dockerfile

--- a/docs/index.html
+++ b/docs/index.html
@@ -30,7 +30,7 @@
         <a href="#commands">Commands</a>
         <a href="#quick-start">Quick Start</a>
         <a href="#setup-guide">Setup Guide</a>
-        <a href="https://github.com/lazaroagomez/BeatDock" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/albertgmz/BeatDock" target="_blank" rel="noopener">GitHub</a>
       </div>
       <div class="navbar__actions">
         <!-- Public bot instance disabled -->
@@ -51,7 +51,7 @@
       <p class="hero__subtitle">A Discord music bot powered by Lavalink. Simple to deploy, easy to use.</p>
       <div class="hero__actions">
         <!-- Public bot instance disabled -->
-        <a href="https://github.com/lazaroagomez/BeatDock" class="btn btn--primary btn--lg" target="_blank" rel="noopener">
+        <a href="https://github.com/albertgmz/BeatDock" class="btn btn--primary btn--lg" target="_blank" rel="noopener">
           <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0C5.37 0 0 5.37 0 12c0 5.31 3.435 9.795 8.205 11.385.6.105.825-.255.825-.57 0-.285-.015-1.23-.015-2.235-3.015.555-3.795-.735-4.035-1.41-.135-.345-.72-1.41-1.23-1.695-.42-.225-1.02-.78-.015-.795.945-.015 1.62.87 1.845 1.23 1.08 1.815 2.805 1.305 3.495.99.105-.78.42-1.305.765-1.605-2.67-.3-5.46-1.335-5.46-5.925 0-1.305.465-2.385 1.23-3.225-.12-.3-.54-1.53.12-3.18 0 0 1.005-.315 3.3 1.23.96-.27 1.98-.405 3-.405s2.04.135 3 .405c2.295-1.56 3.3-1.23 3.3-1.23.66 1.65.24 2.88.12 3.18.765.84 1.23 1.905 1.23 3.225 0 4.605-2.805 5.625-5.475 5.925.435.375.81 1.095.81 2.22 0 1.605-.015 2.895-.015 3.3 0 .315.225.69.825.57A12.02 12.02 0 0 0 24 12c0-6.63-5.37-12-12-12z"/></svg>
           View on GitHub
         </a>
@@ -403,9 +403,9 @@ docker compose pull && \
       <div class="footer__links">
         <div class="footer__column">
           <h4 class="footer__heading">Project</h4>
-          <a href="https://github.com/lazaroagomez/BeatDock" target="_blank" rel="noopener">GitHub</a>
-          <a href="https://github.com/lazaroagomez/BeatDock/issues" target="_blank" rel="noopener">Issues</a>
-          <a href="https://github.com/lazaroagomez/BeatDock/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
+          <a href="https://github.com/albertgmz/BeatDock" target="_blank" rel="noopener">GitHub</a>
+          <a href="https://github.com/albertgmz/BeatDock/issues" target="_blank" rel="noopener">Issues</a>
+          <a href="https://github.com/albertgmz/BeatDock/blob/main/CHANGELOG.md" target="_blank" rel="noopener">Changelog</a>
         </div>
         <div class="footer__column">
           <h4 class="footer__heading">Resources</h4>
@@ -416,7 +416,7 @@ docker compose pull && \
         <div class="footer__column">
           <h4 class="footer__heading">Support</h4>
           <a href="https://ko-fi.com/lazaroagomez" target="_blank" rel="noopener">Ko-fi</a>
-          <a href="https://github.com/lazaroagomez/BeatDock/blob/main/.github/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+          <a href="https://github.com/albertgmz/BeatDock/blob/main/.github/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
         </div>
       </div>
     </div>

--- a/package.json
+++ b/package.json
@@ -27,12 +27,12 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "https://github.com/lazaroagomez/BeatDock.git"
+    "url": "https://github.com/albertgmz/BeatDock.git"
   },
   "bugs": {
-    "url": "https://github.com/lazaroagomez/BeatDock/issues"
+    "url": "https://github.com/albertgmz/BeatDock/issues"
   },
-  "homepage": "https://github.com/lazaroagomez/BeatDock#readme",
+  "homepage": "https://github.com/albertgmz/BeatDock#readme",
   "engines": {
     "node": ">=22.16.0",
     "npm": ">=11.4.2"

--- a/src/commands/about.js
+++ b/src/commands/about.js
@@ -84,12 +84,12 @@ module.exports = {
                 new ButtonBuilder()
                     .setLabel('GitHub Repository')
                     .setStyle(ButtonStyle.Link)
-                    .setURL('https://github.com/lazaroagomez/BeatDock')
+                    .setURL('https://github.com/albertgmz/BeatDock')
                     .setEmoji('⭐'),
                 new ButtonBuilder()
                     .setLabel('Report an Issue')
                     .setStyle(ButtonStyle.Link)
-                    .setURL('https://github.com/lazaroagomez/BeatDock/issues')
+                    .setURL('https://github.com/albertgmz/BeatDock/issues')
                     .setEmoji('🐛')
             );
 

--- a/src/events/guildCreate.js
+++ b/src/events/guildCreate.js
@@ -35,7 +35,7 @@ module.exports = {
                 new ButtonBuilder()
                     .setLabel('GitHub')
                     .setStyle(ButtonStyle.Link)
-                    .setURL('https://github.com/lazaroagomez/BeatDock')
+                    .setURL('https://github.com/albertgmz/BeatDock')
             );
 
         try {


### PR DESCRIPTION
## Summary

The GitHub account was renamed `lazaroagomez` → `albertgmz`. GitHub auto-redirects repo web/git URLs, but **GHCR image paths do not redirect** — the published image moved to `ghcr.io/albertgmz/beatdock` while `ghcr.io/lazaroagomez/beatdock` now returns 403. This updates all hardcoded GitHub references so nothing relies on the old username's redirects (which break if someone claims the now-free `lazaroagomez` handle).

## What changed (11 files, GitHub refs only)

- `docker-compose.yml` + `README.md` — image path → `ghcr.io/albertgmz/beatdock:latest`
- `README.md` — all shields.io badges, clone URL, website (`albertgmz.github.io`), issue links
- `package.json` — `repository`, `bugs`, `homepage` URLs
- `docs/index.html` — nav/footer GitHub, issues, changelog, contributing links
- `.github/` — `CODEOWNERS` (`@albertgmz`), `CONTRIBUTING.md`, `SUPPORT.md`, `ISSUE_TEMPLATE/config.yml`
- `src/commands/about.js`, `src/events/guildCreate.js` — in-bot GitHub button URLs
- `CHANGELOG.md` — historical compare links

## Intentionally NOT changed

- **Ko-fi handle** stays `ko-fi.com/lazaroagomez` (`.github/FUNDING.yml`, README badge, `docs/index.html`) — that account was not renamed.

Verified: `git grep lazaroagomez` returns only the 3 Ko-fi references.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image reference for deployments.
  * Updated GitHub repository links across documentation, configuration files, and in-application features including help, about, and welcome messages.
  * Updated package metadata and configuration to reflect new repository location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->